### PR TITLE
fixt left over if (1) statment from previous calibration and set

### DIFF
--- a/TOF_calib/src/doadctimeoffsets.C
+++ b/TOF_calib/src/doadctimeoffsets.C
@@ -196,7 +196,7 @@ void doadctimeoffsets(int RunNumber){
 
     float THESHIFT = TShift;
     
-    if (1) { // make offset 0: TEMPORARY FIX
+    if (0) { // make offset 0: TEMPORARY FIX
       int S = (int)TShift / (int)4;
       S -= 1;
       if (S<1)


### PR DESCRIPTION
it back to if (0) to ignore that section of code

this error causes the ADC timing to be off by 4ns w.r.t. the TDC timing.