### PR TITLE
Supplying only angle (-a) and not polarization (-p) would accept ALL runs...

### DIFF
--- a/psflux/plot_flux_ccdb.py
+++ b/psflux/plot_flux_ccdb.py
@@ -132,7 +132,11 @@ def main():
 
     # Loop over runs
     for run in runs:
-
+        if RCDB_POLARIZATION == "" and RCDB_POL_ANGLE != "":
+            print "ERROR: polarization angle (option -a or --angle) specified, but polarization flag (option -p or --pol) was not. "
+            print "Please rerun and specify a polarization flag (PARA or PERP) while running"
+            return
+			
         # select run conditions: AMO, PARA, and PERP and polarization angle
         if RCDB_POLARIZATION != "":
             conditions_by_name = run.get_conditions_by_name()


### PR DESCRIPTION
...exit in this case instead now, with a message to supply angle -a and polarization -p arguments.