### PR TITLE
Add photon quality score to flatten.cc

### DIFF
--- a/FlattenForFSRoot/flatten.cc
+++ b/FlattenForFSRoot/flatten.cc
@@ -324,7 +324,9 @@ void ConvertTree(TString treeName){
 
   TClonesArray *inNeutralHypo__P4_Measured = new TClonesArray("TLorentzVector");
       inTree->SetBranchAddress("NeutralHypo__P4_Measured",&(inNeutralHypo__P4_Measured));
-
+  
+  Float_t inShower_Quality[MAXPARTICLES] = {};
+      inTree->SetBranchAddress("NeutralHypo__ShowerQuality", inShower_Quality);
 
         // ************************************
         // ***** 2B. COMBO-DEPENDENT DATA *****

--- a/FlattenForFSRoot/flatten.cc
+++ b/FlattenForFSRoot/flatten.cc
@@ -430,6 +430,7 @@ void ConvertTree(TString treeName){
   float  outPx[MAXPARTICLES]={},  outPy[MAXPARTICLES]={},  outPz[MAXPARTICLES]={},  outEn[MAXPARTICLES]={};
   float outRPx[MAXPARTICLES]={}, outRPy[MAXPARTICLES]={}, outRPz[MAXPARTICLES]={}, outREn[MAXPARTICLES]={};
   float outTkChi2[MAXPARTICLES]={}, outTkNDF[MAXPARTICLES]={};
+  float outQuality[MAXPARTICLES]={};
   {
     for (unsigned int im = 0; im < orderedParticleNames.size(); im++){
     for (unsigned int id = 0; id < orderedParticleNames[im].size(); id++){
@@ -444,6 +445,8 @@ void ConvertTree(TString treeName){
       TString vRPy("RPyP"); vRPy += fsIndex; outTree.Branch(vRPy,&outRPy[pIndex],vRPy+"/F");
       TString vRPz("RPzP"); vRPz += fsIndex; outTree.Branch(vRPz,&outRPz[pIndex],vRPz+"/F");
       TString vREn("REnP"); vREn += fsIndex; outTree.Branch(vREn,&outREn[pIndex],vREn+"/F");
+      TString vQual("Quality"); vQual += fsIndex; outTree.Branch(vQual, &outQuality[pIndex], vQual+"/F");
+      
       if (particleClass(name) == "Charged"){
         TString vTkNDF("TkNDFP"); vTkNDF += fsIndex;
             outTree.Branch(vTkNDF,&outTkNDF[pIndex],vTkNDF+"/F");
@@ -555,6 +558,8 @@ void ConvertTree(TString treeName){
             outRPy[pIndex] = p4->Py();
             outRPz[pIndex] = p4->Pz();
             outREn[pIndex] = p4->E();
+        
+            outQuality[pIndex] = inShower_Quality[pIndex];
         }
 
           // decaying to charged tracks


### PR DESCRIPTION
photons are given their quality scores in output variable "Quality", non-photons are assigned a score of 0.