### PR TITLE
Add study as function of phi; minor QoL changes

### DIFF
--- a/EfficiencyUtilities/NeutralUtilities/AnalyzeOutput/FitHistsMakeEffic.cxx
+++ b/EfficiencyUtilities/NeutralUtilities/AnalyzeOutput/FitHistsMakeEffic.cxx
@@ -46,6 +46,7 @@ Bool_t FCAL_STUDY=true; //true: look for one candidates in FCAL; false: look for
 
 Int_t N_E_BINS = 14; //FCAL
 Int_t N_THETA_BINS = 40; //FCAL
+Int_t N_PHI_BINS = 20; //FCAL+BCAL
 // Int_t N_E_BINS = 20; //BCAL
 // Int_t N_THETA_BINS = 11; //BCAL
 
@@ -321,11 +322,15 @@ Int_t FitOmegaHists(TString str_infile, TString str_outfile) {
 	TH1F* h_m1den_miss_omega_Ebins_accidsub[N_E_BINS];
 	TH1F* h_m1num_miss_omega_Thetabins_accidsub[N_THETA_BINS];
 	TH1F* h_m1den_miss_omega_Thetabins_accidsub[N_THETA_BINS];
+	TH1F* h_m1num_miss_omega_Phibins_accidsub[N_PHI_BINS];
+	TH1F* h_m1den_miss_omega_Phibins_accidsub[N_PHI_BINS];
 	
 	TH1F* h_m2num_inv_omega_Ebins_accidsub[N_E_BINS];
 	TH1F* h_m2denineff_miss_omega_Ebins_accidsub[N_E_BINS];
 	TH1F* h_m2num_inv_omega_Thetabins_accidsub[N_THETA_BINS];
 	TH1F* h_m2denineff_miss_omega_Thetabins_accidsub[N_THETA_BINS];
+	TH1F* h_m2num_inv_omega_Phibins_accidsub[N_PHI_BINS];
+	TH1F* h_m2denineff_miss_omega_Phibins_accidsub[N_PHI_BINS];
 	
  	for(int i =0; i<N_E_BINS; ++i) {
 		char asdfasdf[20];
@@ -347,6 +352,16 @@ Int_t FitOmegaHists(TString str_infile, TString str_outfile) {
 		h_m2num_inv_omega_Thetabins_accidsub[i] = 	(TH1F*)f_in->FindObjectAny("h_m2num_inv_omega_Thetabins_accidsub"+index);
 		h_m2denineff_miss_omega_Thetabins_accidsub[i] = 	(TH1F*)f_in->FindObjectAny("h_m2denineff_miss_omega_Thetabins_accidsub"+index);
 	}			
+ 	for(int i =0; i<N_PHI_BINS; ++i) {
+		char asdfasdf[20];
+		sprintf(asdfasdf,"%d",i);
+		TString index = asdfasdf;
+		
+		h_m1num_miss_omega_Phibins_accidsub[i] = 	(TH1F*)f_in->FindObjectAny("h_m1num_miss_omega_Phibins_accidsub"+index);
+		h_m1den_miss_omega_Phibins_accidsub[i] = 	(TH1F*)f_in->FindObjectAny("h_m1den_miss_omega_Phibins_accidsub"+index);
+		h_m2num_inv_omega_Phibins_accidsub[i] = 	(TH1F*)f_in->FindObjectAny("h_m2num_inv_omega_Phibins_accidsub"+index);
+		h_m2denineff_miss_omega_Phibins_accidsub[i] = 	(TH1F*)f_in->FindObjectAny("h_m2denineff_miss_omega_Phibins_accidsub"+index);
+	}			
 	
 	
 	
@@ -358,11 +373,17 @@ Int_t FitOmegaHists(TString str_infile, TString str_outfile) {
 	Double_t effic_err_m1_Thetabins[N_THETA_BINS];
 	Double_t effic_m2_Thetabins[N_THETA_BINS];
 	Double_t effic_err_m2_Thetabins[N_THETA_BINS];
+	Double_t effic_m1_Phibins[N_PHI_BINS];
+	Double_t effic_err_m1_Phibins[N_PHI_BINS];
+	Double_t effic_m2_Phibins[N_PHI_BINS];
+	Double_t effic_err_m2_Phibins[N_PHI_BINS];
 	
 	Double_t E_arr[N_E_BINS];
 	Double_t E_arr_err[N_E_BINS];
 	Double_t Theta_arr[N_THETA_BINS];
 	Double_t Theta_arr_err[N_THETA_BINS];
+	Double_t Phi_arr[N_PHI_BINS];
+	Double_t Phi_arr_err[N_PHI_BINS];
 	
 	Double_t chi2_m1_num_Ebins_arr[N_E_BINS];
 	Double_t chi2_m1_den_Ebins_arr[N_E_BINS];
@@ -372,6 +393,10 @@ Int_t FitOmegaHists(TString str_infile, TString str_outfile) {
 	Double_t chi2_m1_den_Thetabins_arr[N_THETA_BINS];
 	Double_t chi2_m2_inv_Thetabins_arr[N_THETA_BINS];
 	Double_t chi2_m2_ineff_Thetabins_arr[N_THETA_BINS];
+	Double_t chi2_m1_num_Phibins_arr[N_PHI_BINS];
+	Double_t chi2_m1_den_Phibins_arr[N_PHI_BINS];
+	Double_t chi2_m2_inv_Phibins_arr[N_PHI_BINS];
+	Double_t chi2_m2_ineff_Phibins_arr[N_PHI_BINS];
 	
 	
 	//Fit histograms
@@ -486,6 +511,88 @@ Int_t FitOmegaHists(TString str_infile, TString str_outfile) {
 		// cout << "chi2 m2_inv " << m2_inv_info[3] << endl;
 		// cout << "chi2 m2_ineff " << m2_ineff_info[3] << endl;
 		
+	}
+	
+	
+ 	for(int i =0; i<N_PHI_BINS; ++i) {
+		char asdfasdf[20];
+		sprintf(asdfasdf,"%d",i);
+		TString index = asdfasdf;
+		
+		Phi_arr[i] = -171+18*i;
+		Phi_arr_err[i] = 0.;
+		
+		cout << "Phi bin: " << Phi_arr[i] << endl;
+		
+		if(h_m1num_miss_omega_Phibins_accidsub[i]->GetEntries()<50 || h_m1den_miss_omega_Phibins_accidsub[i]->GetEntries()<50 || h_m2num_inv_omega_Phibins_accidsub[i]->GetEntries()<50 || h_m2denineff_miss_omega_Phibins_accidsub[i]->GetEntries()<50) {
+			effic_m1_Phibins[i] = 0;
+			effic_err_m1_Phibins[i] = 0;
+			effic_m2_Phibins[i] = 0;
+			effic_err_m2_Phibins[i] = 0;
+			chi2_m1_num_Phibins_arr[i] = 0;
+			chi2_m1_den_Phibins_arr[i] = 0;
+			chi2_m2_inv_Phibins_arr[i] = 0;
+			chi2_m2_ineff_Phibins_arr[i] = 0;
+			continue;
+		}
+		
+		
+		vector<Double_t> m1_num_info = jz_fitandsave_omega_MM_3gaus(h_m1num_miss_omega_Phibins_accidsub[i],"m1_num_Phibin_"+index);
+		vector<Double_t> m1_den_info = jz_fitandsave_omega_MM_3gaus(h_m1den_miss_omega_Phibins_accidsub[i],"m1_den_Phibin_"+index);
+		// vector<Double_t> m2_inv_info = jz_fitandsave_omega_MM_2gaus(h_m2num_inv_omega_Phibins_accidsub[i],"m2_inv_Phibin_"+index);
+		vector<Double_t> m2_inv_info = jz_fitandsave_omega_MM_3gaus(h_m2num_inv_omega_Phibins_accidsub[i],"m2_inv_Phibin_"+index);
+		vector<Double_t> m2_ineff_info = jz_fitandsave_omega_MM_3gaus(h_m2denineff_miss_omega_Phibins_accidsub[i],"m2_ineff_Phibin_"+index);
+	
+	
+		if(m1_num_info[0]==0||m1_den_info[0]==0) {
+			effic_m1_Phibins[i]=0;
+			effic_err_m1_Phibins[i]=0;
+		}
+		if(m2_inv_info[0]==0||m2_ineff_info[0]==0) {
+			effic_m2_Phibins[i]=0;
+			effic_err_m2_Phibins[i]=0;
+		}
+		
+	
+		effic_m1_Phibins[i] = m1_num_info[0]/m1_den_info[0];
+		effic_err_m1_Phibins[i] = effic_m1_Phibins[i]*sqrt( (m1_num_info[1]/m1_num_info[0])*(m1_num_info[1]/m1_num_info[0]) +(m1_den_info[1]/m1_den_info[0])*(m1_den_info[1]/m1_den_info[0])  );
+		
+		Double_t m2_den = (m2_inv_info[0]+m2_ineff_info[0]);
+		effic_m2_Phibins[i] = m2_inv_info[0]/ m2_den;
+		//Wrong!!! But I'm rushed right now, should fix to have proper cov stuff later
+		effic_err_m2_Phibins[i] = effic_m2_Phibins[i]*sqrt( (m2_inv_info[1]/m2_inv_info[0])*(m2_inv_info[1]/m2_inv_info[0]) + 1/m2_den  );
+	
+		chi2_m1_num_Phibins_arr[i] = m1_num_info[3];
+		chi2_m1_den_Phibins_arr[i] = m1_den_info[3];
+		chi2_m2_inv_Phibins_arr[i] = m2_inv_info[3];
+		chi2_m2_ineff_Phibins_arr[i] = m2_ineff_info[3];
+		
+		if(effic_m1_Phibins[i] > 1.3) {
+			effic_m1_Phibins[i] = 0;
+			effic_err_m1_Phibins[i] = 0;
+		}
+		if(effic_m2_Phibins[i] > 1.3) {
+			effic_m2_Phibins[i] = 0;
+			effic_err_m2_Phibins[i] = 0;
+		}
+		
+		// cout << "m1_num yield: " << m1_num_info[0] << endl;
+		// cout << "m1_den yield: " << m1_den_info[0] << endl;
+		// cout << "m1 efficiency: " << effic_m1_Thetabins[i] << endl;
+		// cout << "m2_inv yield: " << m2_inv_info[0] << endl;
+		// cout << "m2_ineff yield: " << m2_ineff_info[0] << endl;
+		// cout << "m2 efficiency: " << effic_m2_Thetabins[i] << endl;
+		
+		// cout << "Signal yield / total m1_num: " << m1_num_info[0]/h_m1num_miss_omega_Thetabins_accidsub[i]->GetEntries() << endl;
+		// cout << "Signal yield / total m1_den: " << m1_den_info[0]/h_m1den_miss_omega_Thetabins_accidsub[i]->GetEntries() << endl;
+		// cout << "Signal yield / total m2_inv: " << m2_inv_info[0]/h_m2num_inv_omega_Thetabins_accidsub[i]->GetEntries() << endl;
+		// cout << "Signal yield / total m2_ineff: " << m2_ineff_info[0]/h_m2denineff_miss_omega_Thetabins_accidsub[i]->GetEntries() << endl;
+	
+		// cout << "chi2 m1_num " << m1_num_info[3] << endl;
+		// cout << "chi2 m1_den " << m1_den_info[3] << endl;
+		// cout << "chi2 m2_inv " << m2_inv_info[3] << endl;
+		// cout << "chi2 m2_ineff " << m2_ineff_info[3] << endl;
+		
 		cout << "Done with fitting for bin: " << i << endl;
 	}
 	
@@ -499,15 +606,24 @@ Int_t FitOmegaHists(TString str_infile, TString str_outfile) {
 		cout << "Efficiency method 1: " << effic_m1_Thetabins[i] << " +- " << effic_err_m1_Thetabins[i] << endl;
 		cout << "Efficiency method 2: " << effic_m2_Thetabins[i] << " +- " << effic_err_m2_Thetabins[i] << endl;
 	}
+	for(int i =0; i<N_PHI_BINS; ++i) {
+		cout << "Phi bin: " << i << endl;
+		cout << "Efficiency method 1: " << effic_m1_Phibins[i] << " +- " << effic_err_m1_Phibins[i] << endl;
+		cout << "Efficiency method 2: " << effic_m2_Phibins[i] << " +- " << effic_err_m2_Phibins[i] << endl;
+	}
 	
 	TGraphErrors* gr_m1_effic_Ebins = new TGraphErrors(N_E_BINS,E_arr,effic_m1_Ebins,E_arr_err,effic_err_m1_Ebins);
 	gr_m1_effic_Ebins->SetName("gr_m1_effic_Ebins");
 	TGraphErrors* gr_m1_effic_Thetabins = new TGraphErrors(N_THETA_BINS,Theta_arr,effic_m1_Thetabins,Theta_arr_err,effic_err_m1_Thetabins);
 	gr_m1_effic_Thetabins->SetName("gr_m1_effic_Thetabins");
+	TGraphErrors* gr_m1_effic_Phibins = new TGraphErrors(N_PHI_BINS,Phi_arr,effic_m1_Phibins,Phi_arr_err,effic_err_m1_Phibins);
+	gr_m1_effic_Phibins->SetName("gr_m1_effic_Phibins");
 	TGraphErrors* gr_m2_effic_Ebins = new TGraphErrors(N_E_BINS,E_arr,effic_m2_Ebins,E_arr_err,effic_err_m2_Ebins);
 	gr_m2_effic_Ebins->SetName("gr_m2_effic_Ebins");
 	TGraphErrors* gr_m2_effic_Thetabins = new TGraphErrors(N_THETA_BINS,Theta_arr,effic_m2_Thetabins,Theta_arr_err,effic_err_m2_Thetabins);
 	gr_m2_effic_Thetabins->SetName("gr_m2_effic_Thetabins");
+	TGraphErrors* gr_m2_effic_Phibins = new TGraphErrors(N_PHI_BINS,Phi_arr,effic_m2_Phibins,Phi_arr_err,effic_err_m2_Phibins);
+	gr_m2_effic_Phibins->SetName("gr_m2_effic_Phibins");
 	
 	TGraph* gr_m1_num_chi2_Ebins = new TGraph(N_E_BINS,E_arr,chi2_m1_num_Ebins_arr);
 	TGraph* gr_m1_den_chi2_Ebins = new TGraph(N_E_BINS,E_arr,chi2_m1_den_Ebins_arr);
@@ -525,6 +641,14 @@ Int_t FitOmegaHists(TString str_infile, TString str_outfile) {
 	gr_m1_den_chi2_Thetabins->SetName("gr_m1_den_chi2_Thetabins");
 	gr_m2_inv_chi2_Thetabins->SetName("gr_m2_inv_chi2_Thetabins");
 	gr_m2_ineff_chi2_Thetabins->SetName("gr_m2_ineff_chi2_Thetabins");
+	TGraph* gr_m1_num_chi2_Phibins = new TGraph(N_PHI_BINS,Phi_arr,chi2_m1_num_Phibins_arr);
+	TGraph* gr_m1_den_chi2_Phibins = new TGraph(N_PHI_BINS,Phi_arr,chi2_m1_den_Phibins_arr);
+	TGraph* gr_m2_inv_chi2_Phibins = new TGraph(N_PHI_BINS,Phi_arr,chi2_m2_inv_Phibins_arr);
+	TGraph* gr_m2_ineff_chi2_Phibins = new TGraph(N_PHI_BINS,Phi_arr,chi2_m2_ineff_Phibins_arr);
+	gr_m1_num_chi2_Phibins->SetName("gr_m1_num_chi2_Phibins");
+	gr_m1_den_chi2_Phibins->SetName("gr_m1_den_chi2_Phibins");
+	gr_m2_inv_chi2_Phibins->SetName("gr_m2_inv_chi2_Phibins");
+	gr_m2_ineff_chi2_Phibins->SetName("gr_m2_ineff_chi2_Phibins");
 	
 	TFile* outfile = new TFile( str_outfile, "RECREATE" );
 	outfile->cd();
@@ -532,6 +656,8 @@ Int_t FitOmegaHists(TString str_infile, TString str_outfile) {
 	gr_m2_effic_Ebins->Write();
 	gr_m1_effic_Thetabins->Write();
 	gr_m2_effic_Thetabins->Write();
+	gr_m1_effic_Phibins->Write();
+	gr_m2_effic_Phibins->Write();
 	gr_m1_num_chi2_Ebins->Write();
 	gr_m1_den_chi2_Ebins->Write();
 	gr_m2_inv_chi2_Ebins->Write();
@@ -540,6 +666,10 @@ Int_t FitOmegaHists(TString str_infile, TString str_outfile) {
 	gr_m1_den_chi2_Thetabins->Write();
 	gr_m2_inv_chi2_Thetabins->Write();
 	gr_m2_ineff_chi2_Thetabins->Write();
+	gr_m1_num_chi2_Phibins->Write();
+	gr_m1_den_chi2_Phibins->Write();
+	gr_m2_inv_chi2_Phibins->Write();
+	gr_m2_ineff_chi2_Phibins->Write();
 	outfile->Close();
 	
 	return 0;

--- a/EfficiencyUtilities/NeutralUtilities/AnalyzeOutput/GetShowerLvlEffic.py
+++ b/EfficiencyUtilities/NeutralUtilities/AnalyzeOutput/GetShowerLvlEffic.py
@@ -14,29 +14,57 @@ from math import sqrt, exp
 
 #Root stuff
 from ROOT import TFile, TTree, TBranch, TLorentzVector, TLorentzRotation, TVector3
-from ROOT import TCanvas, TMath, TH2F, TH1F, TRandom, TGraphErrors, TAxis
+from ROOT import TCanvas, TMath, TH2F, TH1F, TRandom, TGraphErrors, TAxis, TF1, TGraph
 from ROOT import gBenchmark, gDirectory, gROOT
 
 #My Stuff
 #Required: add to PYTHONPATH environment variable, e.g.
 #setenv PYTHONPATH /gpfs/home/j/z/jzarling/Karst/MyAnalyses/Python_stuff/jz_library/:$PYTHONPATH
-# from jz_pyroot_helper import *
-#from jz_pyroot_FitMacros import *
+from jz_pyroot_helper import *
+from jz_pyroot_FitMacros import *
 
-SCAN_OVER_ENERGY = True
-SCAN_OVER_THETA  = False
-# SCAN_OVER_ENERGY = False
-# SCAN_OVER_THETA  = True
+# PLOT_TAG = ""
+PLOT_TAG = "G4"
+# PLOT_TAG = "G3"
+
+# SCAN_OVER_ENERGY = True
+# SCAN_OVER_THETA  = False
+SCAN_OVER_ENERGY = False
+SCAN_OVER_THETA  = True
+
+IS_FCAL = True # Name of folders and whether to use NFCALShowers or NBCALShowers. That's it.
+USE_EDIST_FOR_FITTING = True #If true, get efficiency from gaussian core of energy. If false, use Delta_phi gaussian core instead.
+ZERO_OR_ONE_SHOWERS_ONLY = False #If true, remove 2+ showers from numerator and denominator
+
+shower_hist_name = "h_foundE_DeltaPhiCuts_dist"
+# shower_hist_name = "h_foundE_1show_dist"
+# shower_hist_name = "h_DeltaPhi_all"
 
 POLY_ORDER = 2 #Set to 0 for pure gaussian
-E_BELOWTHROWN_TOFIT = 0.7 # lower range of histogram fitting: E_thrown - this_val
-E_ABOVETHROWN_TOFIT = 0.5 # upper range of histogram fitting: E_thrown + this_val
+# VAL_BELOWTHROWN_TOFIT = 0.7 # Good for fitting E in FCAL. lower range of histogram fitting: E_thrown - this_val
+# VAL_ABOVETHROWN_TOFIT = 0.5 # Good for fitting E in FCAL. upper range of histogram fitting: E_thrown + this_val
+VAL_BELOWTHROWN_TOFIT = 0.5 # Good for fitting deltaPhi (comparing theta). lower range of histogram fitting: E_thrown - this_val
+VAL_ABOVETHROWN_TOFIT = 0.3 # Good for fitting deltaPhi (comparing theta). upper range of histogram fitting: E_thrown + this_val
+# VAL_BELOWTHROWN_TOFIT = 3 # Good for fitting deltaPhi (scanning E). lower range of histogram fitting: E_thrown - this_val
+# VAL_ABOVETHROWN_TOFIT = 3 # Good for fitting deltaPhi (scanning E). upper range of histogram fitting: E_thrown + this_val
+TWO_GAUS = True #Not implemented properly yet
 
 MIN_EVENTS = 10
 
+#Colors
+kRed = 632
+kOrange = 800
+kYellow = 400
+kGreen = 416
+kBlue = 600
+kViolet = 880
+kMagenta = 616
+kBlack = 1
 
 
 def main(argv):
+
+
 	#Usage controls from OptionParser
 	parser_usage = "outputfile.root filename1.root ... filenameN.root"
 	parser = OptionParser(usage = parser_usage)
@@ -52,7 +80,13 @@ def main(argv):
 		print "ERROR: neither scan flags turned on! Please select either energy or theta to scan over..."
 		return
 		
+		
+	gStyle.SetOptFit(11111) #Show fit results in panel
 	c1 = TCanvas("c1","c1",1600,900)
+	
+	BASE_FOLDER_STRING = ""
+	if(IS_FCAL is True): BASE_FOLDER_STRING="FCAL_photon_gun_hists"
+	else: BASE_FOLDER_STRING="BCAL_photon_gun_hists"
 	
 	file_list = []
 	curr_E_val = 0.1
@@ -71,57 +105,99 @@ def main(argv):
 	effic_gauscore_1show_err_arr = array('d',[])
 	effic_anyquality_1show_arr = array('d',[])
 	effic_anyquality_1show_err_arr = array('d',[])
-		
+	
+	avg_reconE_arr = array('d',[])
+	
 	# curr_E_val = 0.1
 	for i in range(0,len(file_list)):
 		print "Current file: " + argv[i+1]
 		
 		
 		#For normalization
-		h_curr_showers = file_list[i].Get("photon_gun_hists/h_NFCALShowers")
+		if IS_FCAL: h_curr_showers = file_list[i].Get(BASE_FOLDER_STRING+"/h_NFCALShowers")
+		else: h_curr_showers = file_list[i].Get(BASE_FOLDER_STRING+"/h_NBCALShowers")
 		h_ThrownPhotonE_curr = TH1F()
 		h_ThrownPhotonTheta_curr = TH1F()
-		h_ThrownPhotonE_curr = file_list[i].Get("photon_gun_hists/h_ThrownPhotonE")
-		h_ThrownPhotonTheta_curr  = file_list[i].Get("photon_gun_hists/h_thrownTheta")
+		h_ThrownPhotonE_curr = file_list[i].Get(BASE_FOLDER_STRING+"/h_ThrownPhotonE")
+		h_ThrownPhotonTheta_curr  = file_list[i].Get(BASE_FOLDER_STRING+"/h_thrownTheta")
 		norm_count = h_ThrownPhotonE_curr.GetEntries()
+		print "Denominator: " + str(norm_count)
+		
+		# print "Norm count is: " + str(norm_count)
+		for j in range(0,h_curr_showers.GetNbinsX()):
+			if(h_curr_showers.GetBinCenter(j) > 1 and h_curr_showers.GetBinContent(j)>0):
+				# print "reducing norm count by " + str(h_curr_showers.GetBinContent(j))
+				if ZERO_OR_ONE_SHOWERS_ONLY: norm_count-=h_curr_showers.GetBinContent(j)
+		# print "Now norm count is: " + str(norm_count)
+		
 		if(norm_count < MIN_EVENTS): continue
 		atleast_one_shower = norm_count-h_curr_showers.GetBinContent(1) #Bin 1 corresponds to 0 showers
 		# curr_E_val = my_gaus_fit.GetParameter(1)
-		curr_E_val = h_ThrownPhotonE_curr.GetBinLowEdge( h_ThrownPhotonE_curr.GetMaximumBin()+1 )
-		curr_theta_val = h_ThrownPhotonTheta_curr.GetBinLowEdge( h_ThrownPhotonTheta_curr.GetMaximumBin()+1 )
+		# curr_E_val = h_ThrownPhotonE_curr.GetBinLowEdge( h_ThrownPhotonE_curr.GetMaximumBin()+1 )
+		curr_E_val = h_ThrownPhotonE_curr.GetMean()
+		curr_theta_val = h_ThrownPhotonTheta_curr.GetMean()
 		print "Current theta: " + str(curr_theta_val)
 		
 		# h_curr = file_list[i].Get("h_foundE_all_dist")
-		h_curr = file_list[i].Get("photon_gun_hists/h_foundE_DeltaPhiCuts_dist")
-		my_gaus_fit = TF1("my_gaus_fit","gausn",0.001,3.)
+		h_curr = file_list[i].Get(BASE_FOLDER_STRING+"/"+shower_hist_name)
+		#Fit once with pure gaussian
+		fit_center = curr_E_val #Fiting around reconstructed energy.
+		if(not USE_EDIST_FOR_FITTING): fit_center = 0 #Fitting DeltaPhi instead, should be centered around 0.
+		my_gaus_fit = TF1("my_gaus_fit","gausn+gausn(3)",0.001,3.)
 		my_gaus_fit.SetParLimits(0,0,10000)
-		my_gaus_fit.SetParLimits(1,curr_E_val-0.2,curr_E_val+0.1)
+		my_gaus_fit.SetParLimits(1,fit_center-0.2,fit_center+0.1)
 		my_gaus_fit.SetParLimits(2,0.005,0.4)
+		my_gaus_fit.SetParLimits(0+3,0,10000)
+		my_gaus_fit.SetParLimits(1+3,fit_center-0.2,fit_center+0.1)
+		my_gaus_fit.SetParLimits(2+3,0.005,0.4)
 		my_gaus_fit.SetNpx(1000);
-		h_curr.GetXaxis().SetRangeUser(curr_E_val-1.2,curr_E_val+0.5)
-		h_curr.Fit(my_gaus_fit,"Q","",curr_E_val-E_BELOWTHROWN_TOFIT,curr_E_val+E_ABOVETHROWN_TOFIT)
-		h_curr.Fit(my_gaus_fit,"QL","",curr_E_val-E_BELOWTHROWN_TOFIT,curr_E_val+E_ABOVETHROWN_TOFIT)
+		if(curr_E_val < 0.26 and not IS_FCAL): my_gaus_fit.FixParameter(3,0) # One gaussian only
+		h_curr.GetXaxis().SetRangeUser(fit_center-VAL_BELOWTHROWN_TOFIT*2,fit_center+VAL_ABOVETHROWN_TOFIT*2)
+		h_curr.Fit(my_gaus_fit,"Q","",fit_center-VAL_BELOWTHROWN_TOFIT,fit_center+VAL_ABOVETHROWN_TOFIT)
+		h_curr.Fit(my_gaus_fit,"QL","",fit_center-VAL_BELOWTHROWN_TOFIT,fit_center+VAL_ABOVETHROWN_TOFIT)
+		
 		
 		if(POLY_ORDER>=1):
 			gaus_fit_amplitude = my_gaus_fit.GetParameter(0)
-			gaus_fit_mean      = my_gaus_fit.GetParameter(1)
-			gaus_fit_sigma     = my_gaus_fit.GetParameter(2)
-			
-			gaus_plus_poly_fit = TF1("gaus_plus_poly_fit","gausn+pol"+str(POLY_ORDER)+"(3)",0.001,3.)
+			gaus_fit_mean	  = my_gaus_fit.GetParameter(1)
+			gaus_fit_sigma	 = my_gaus_fit.GetParameter(2)
+			gaus_fit_amplitude2 = my_gaus_fit.GetParameter(0+3)
+			gaus_fit_mean2	  = my_gaus_fit.GetParameter(1+3)
+			gaus_fit_sigma2	 = my_gaus_fit.GetParameter(2+3)
+						
+			gaus_plus_poly_fit = TF1("gaus_plus_poly_fit","gausn+gausn(3)+pol"+str(POLY_ORDER)+"(6)",0.001,3.)
 			gaus_plus_poly_fit.SetParameter(0,gaus_fit_amplitude)
 			gaus_plus_poly_fit.SetParameter(1,gaus_fit_mean)
 			gaus_plus_poly_fit.SetParameter(2,gaus_fit_sigma)
+			gaus_plus_poly_fit.SetParameter(0+3,gaus_fit_amplitude2)
+			gaus_plus_poly_fit.SetParameter(1+3,gaus_fit_mean2)
+			gaus_plus_poly_fit.SetParameter(2+3,gaus_fit_sigma2)
 			gaus_plus_poly_fit.SetParLimits(0,0,10000)
-			gaus_plus_poly_fit.SetParLimits(1,curr_E_val-0.2,curr_E_val+0.1)
-			gaus_plus_poly_fit.SetParLimits(2,0.005,0.4)
+			gaus_plus_poly_fit.SetParLimits(1,fit_center-0.2,fit_center+0.1)
+			gaus_plus_poly_fit.SetParLimits(2,0.005,0.7)
+			gaus_plus_poly_fit.SetParNames("YieldUnnorm","Mean","#sigma","YieldUnnorm2","Mean2","#sigma2","pol0","pol1","pol2","pol3")
 			
-			h_curr.Fit(gaus_plus_poly_fit,"Q","",curr_E_val-E_BELOWTHROWN_TOFIT,curr_E_val+E_ABOVETHROWN_TOFIT)
-			h_curr.Fit(gaus_plus_poly_fit,"QL","",curr_E_val-E_BELOWTHROWN_TOFIT,curr_E_val+E_ABOVETHROWN_TOFIT)
+			# Need different fitting routine for low energy BCAL showers
+			if(curr_E_val < 0.26 and not IS_FCAL):
+				my_gaus_fit.FixParameter(3,0) # One gaussian only
+				for i in range(0,POLY_ORDER+1):
+					my_gaus_fit.FixParameter(6+i,0)
+			
+			h_curr.Fit(gaus_plus_poly_fit,"Q","",fit_center-VAL_BELOWTHROWN_TOFIT,fit_center+VAL_ABOVETHROWN_TOFIT)
+			h_curr.Fit(gaus_plus_poly_fit,"QL","",fit_center-VAL_BELOWTHROWN_TOFIT,fit_center+VAL_ABOVETHROWN_TOFIT)
 		
 		
-		c1.SaveAs(".plots/FitE_"+str(curr_E_val)+".png")
-		effic_gauscore_arr.append((my_gaus_fit.GetParameter(0)/h_curr.GetBinWidth(0))/norm_count)
-		effic_gauscore_err_arr.append(my_gaus_fit.GetParError(0)/h_curr.GetBinWidth(0)/norm_count)
+		if SCAN_OVER_ENERGY: c1.SaveAs(".plots/FitE_"+str(curr_E_val)+"_"+PLOT_TAG+".png")
+		if SCAN_OVER_THETA: c1.SaveAs(".plots/FitTheta_"+str(curr_theta_val)+"_"+PLOT_TAG+".png")
+		if(curr_E_val> 0.28 or IS_FCAL):
+			effic_gauscore_arr.append(((my_gaus_fit.GetParameter(0)+my_gaus_fit.GetParameter(3))/h_curr.GetBinWidth(0))/norm_count)
+			effic_gauscore_err_arr.append( sqrt((my_gaus_fit.GetParameter(0)+my_gaus_fit.GetParameter(3))//h_curr.GetBinWidth(0))/norm_count)
+		if(curr_E_val<0.28 and not IS_FCAL):
+			effic_gauscore_arr.append(h_curr.GetEntries()/norm_count)
+			effic_gauscore_err_arr.append(  sqrt(h_curr.GetEntries())/norm_count)
+		
+		avg_reconE_arr.append(h_curr.GetMean())
+		
 		effic_anyquality_arr.append(atleast_one_shower/norm_count)
 		effic_anyquality_err_arr.append(0)
 		if(SCAN_OVER_ENERGY): scan_val_arr.append(curr_E_val)
@@ -147,15 +223,21 @@ def main(argv):
 		# effic_anyquality_1show_arr.append((10000.-h_curr.GetBinContent(1))/10000)
 		# effic_anyquality_1show_err_arr.append(0)
 	
+	for i in range(0,len(scan_val_arr)):
+		print "Value: " + str(scan_val_arr[i])
+		print "Efficiency: " + str(effic_gauscore_arr[i])
+		print ""
+	
 	gr_gauscore_effic = TGraphErrors( len(file_list), scan_val_arr, effic_gauscore_arr, scan_val_arr_arr_err, effic_gauscore_err_arr)
 	gr_gauscore_effic.SetMarkerStyle(15)
 	gr_gauscore_effic.SetMarkerSize(1.2)
 	gr_gauscore_effic.SetMarkerColor(kBlue)
 	gr_gauscore_effic.SetName("gr_gauscore_effic")
 	gr_gauscore_effic.SetTitle("Efficiency at 1 GeV")
-	gr_gauscore_effic.GetXaxis().SetTitle("Photon #theta (degrees)")
+	if(SCAN_OVER_ENERGY): gr_gauscore_effic.GetXaxis().SetTitle("E_{#gamma} (GeV)")
+	if(SCAN_OVER_THETA): gr_gauscore_effic.GetXaxis().SetTitle("Photon #theta (degrees)")
 	gr_gauscore_effic.GetYaxis().SetTitle("Efficiency")
-	gr_gauscore_effic.GetXaxis().SetRangeUser(0,12.)
+	# gr_gauscore_effic.GetXaxis().SetRangeUser(0,12.)
 	
 	gr_anyquality_effic = TGraphErrors( len(file_list), scan_val_arr, effic_anyquality_arr, scan_val_arr_arr_err, effic_anyquality_err_arr)
 	gr_anyquality_effic.SetName("gr_anyquality_effic")
@@ -179,10 +261,15 @@ def main(argv):
 	gr_anyquality_effic.Draw("AP")
 	c1.SaveAs("AnyQualityEfficiency.png")
 		
+	gr_avg_reconE = TGraph( len(file_list), scan_val_arr, avg_reconE_arr)
+	gr_avg_reconE.SetName("gr_avg_reconE")
+		
+		
 	f_out = TFile(argv[0],"RECREATE")
 	f_out.cd()
 	gr_gauscore_effic.Write()
 	gr_anyquality_effic.Write()
+	gr_avg_reconE.Write()
 	# gr_gauscore_1show_effic.Write()
 	# gr_anyquality_1show_effic.Write()
 	f_out.Close()

--- a/EfficiencyUtilities/NeutralUtilities/AnalyzeOutput/MakeHists.cxx
+++ b/EfficiencyUtilities/NeutralUtilities/AnalyzeOutput/MakeHists.cxx
@@ -40,6 +40,10 @@
 
 Bool_t FCAL_STUDY=true; //true: look for one candidates in FCAL; false: look for one candidate in BCAL
 
+Int_t WHICH_PHOTON_INDEX=0; // For testing possible (but suspected non-) issue of double counting leading to inflated efficiencies
+// If only one photon is found, this variable is not relevant
+// If two photons are found: 0=count each photon once as spectator and test photon, 1=first photon ONLY as test photon, 2=second photon ONLY
+
 Int_t NBeamBunchesOutoftime = 2;
 
 // Double_t m1_pi0cut_lo = 0.08;
@@ -56,14 +60,15 @@ Double_t MISS_THETA_HICUT = 20.5; //FCAL
 // Double_t MISS_THETA_LOCUT = 8; // BCAL
 // Double_t MISS_THETA_HICUT = 38; //BCAL
 
-// Double_t MISS_E_MIN = 0.6; // Good for FCAL
-Double_t MISS_E_MIN = 0.0; // Try for FCAL
+Double_t MISS_E_MIN = 0.6; // Good for FCAL
+// Double_t MISS_E_MIN = 0.0; // Try for FCAL
 
 //Pick a number high enough to suppress rho -> pi+ pi- + fake photon or else missing spectrum (no second candidate) will get screwy!
 Double_t FOUND_E_MIN = 0.5; // Other pi0 photon must have at least this much energy. 0.8 in FCAL would be nice, statistics willing.
 
 Int_t N_E_BINS = 14; // FCAL
 Int_t N_THETA_BINS = 40; //FCAL
+Int_t N_PHI_BINS = 20; //FCAL+BCAL
 // Int_t N_E_BINS = 20; // BCAL
 // Int_t N_THETA_BINS = 11; //BCAL
 
@@ -76,6 +81,10 @@ Double_t gamma1_miss_Emin = 0.8; //For projecting into theta distribution, FCAL
 
 Bool_t USE_THROWN_4VEC=false; //true: replace all 4-vectors with thrown (but not other stuff like pi0 missing mass)
 // Bool_t USE_THROWN_4VEC=true; //true: replace all 4-vectors with thrown (but not other stuff like pi0 missing mass)
+
+Double_t ThrownDeltaPhi_gammastudy = 3.35; //In degrees
+Double_t ThrownDeltaTheta_gammastudy = 0.35; //In degrees
+
 
 Bool_t Redefine_FOUND_E_MIN_cut(Double_t new_val) {
 	FOUND_E_MIN = new_val;
@@ -206,6 +215,34 @@ Int_t GetThetaBinBCAL(Double_t my_theta) {
 	return my_bin;
 }
 
+Int_t GetPhiBin(Double_t my_phi) {
+	
+	Int_t my_bin = -1;
+	if(-180.<my_phi&&my_phi<-162.) my_bin = 0;
+	if(-162.<my_phi&&my_phi<-144.) my_bin = 1;
+	if(-144.<my_phi&&my_phi<-126.) my_bin = 2;
+	if(-126.<my_phi&&my_phi<-108.) my_bin = 3;
+	if(-108.<my_phi&&my_phi<-90.)  my_bin = 4;
+	if(-90.<my_phi&&my_phi<-72.)   my_bin = 5;
+	if(-72.<my_phi&&my_phi<-54.)   my_bin = 6;
+	if(-54.<my_phi&&my_phi<-36.)   my_bin = 7;
+	if(-36.<my_phi&&my_phi<-18.)   my_bin = 8;
+	if(-18.<my_phi&&my_phi<0.)     my_bin = 9;
+	if(0.<my_phi&&my_phi<18.)      my_bin = 10;
+	if(18.<my_phi&&my_phi<36.)     my_bin = 11;
+	if(36.<my_phi&&my_phi<54.)     my_bin = 12;
+	if(54.<my_phi&&my_phi<72.)     my_bin = 13;
+	if(72.<my_phi&&my_phi<90.)     my_bin = 14;
+	if(90.<my_phi&&my_phi<108.)    my_bin = 15;
+	if(108.<my_phi&&my_phi<126.)   my_bin = 16;
+	if(126.<my_phi&&my_phi<144.)   my_bin = 17;
+	if(144.<my_phi&&my_phi<162.)   my_bin = 18;
+	if(162.<my_phi&&my_phi<180.)   my_bin = 19;
+		
+	return my_bin;
+}
+
+
 
 Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown_info_hists = false, Long64_t max_events = 1000000000000) {
 	
@@ -319,6 +356,11 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 	Double_t two_gamma_opangle_thr;  if(make_thrown_info_hists) t_in->SetBranchAddress("two_gamma_opangle_thr",  &two_gamma_opangle_thr);
 	Double_t gam2_ThrRecon_opangle;  if(make_thrown_info_hists) t_in->SetBranchAddress("gam2_ThrRecon_opangle",  &gam2_ThrRecon_opangle);
 	
+	Double_t Gamma1_DeltaTheta; if(make_thrown_info_hists) t_in->SetBranchAddress("Gamma1_DeltaTheta",  &Gamma1_DeltaTheta);
+	Double_t Gamma1_DeltaPhi;   if(make_thrown_info_hists) t_in->SetBranchAddress("Gamma1_DeltaPhi",    &Gamma1_DeltaPhi);
+	Double_t Gamma2_DeltaTheta; if(make_thrown_info_hists) t_in->SetBranchAddress("Gamma2_DeltaTheta",  &Gamma2_DeltaTheta);
+	Double_t Gamma2_DeltaPhi;   if(make_thrown_info_hists) t_in->SetBranchAddress("Gamma2_DeltaPhi",    &Gamma2_DeltaPhi);
+	
 	
 	Long64_t nentries = t_in->GetEntries();
 	cout << "There are " << nentries <<  " events to get through" << endl;
@@ -408,6 +450,12 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 	TH1F* h_m1den_miss_omega_Thetabins_intime[N_THETA_BINS];
 	TH1F* h_m1den_miss_omega_Thetabins_outoftime[N_THETA_BINS];
 	TH1F* h_m1den_miss_omega_Thetabins_accidsub[N_THETA_BINS];
+	TH1F* h_m1num_miss_omega_Phibins_intime[N_PHI_BINS];
+	TH1F* h_m1num_miss_omega_Phibins_outoftime[N_PHI_BINS];
+	TH1F* h_m1num_miss_omega_Phibins_accidsub[N_PHI_BINS];
+	TH1F* h_m1den_miss_omega_Phibins_intime[N_PHI_BINS];
+	TH1F* h_m1den_miss_omega_Phibins_outoftime[N_PHI_BINS];
+	TH1F* h_m1den_miss_omega_Phibins_accidsub[N_PHI_BINS];
 	
 	TH1F* h_m2num_inv_omega_Ebins_intime[N_E_BINS];
 	TH1F* h_m2num_inv_omega_Ebins_outoftime[N_E_BINS];
@@ -421,6 +469,12 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 	TH1F* h_m2denineff_miss_omega_Thetabins_intime[N_THETA_BINS];
 	TH1F* h_m2denineff_miss_omega_Thetabins_outoftime[N_THETA_BINS];
 	TH1F* h_m2denineff_miss_omega_Thetabins_accidsub[N_THETA_BINS];
+	TH1F* h_m2num_inv_omega_Phibins_intime[N_PHI_BINS];
+	TH1F* h_m2num_inv_omega_Phibins_outoftime[N_PHI_BINS];
+	TH1F* h_m2num_inv_omega_Phibins_accidsub[N_PHI_BINS];
+	TH1F* h_m2denineff_miss_omega_Phibins_intime[N_PHI_BINS];
+	TH1F* h_m2denineff_miss_omega_Phibins_outoftime[N_PHI_BINS];
+	TH1F* h_m2denineff_miss_omega_Phibins_accidsub[N_PHI_BINS];
 	
  	for(int i =0; i<N_E_BINS; ++i) {
 		char asdfasdf[20];
@@ -460,6 +514,25 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 		h_m2denineff_miss_omega_Thetabins_outoftime[i] = new TH1F("h_m2denineff_miss_omega_Thetabins_outoftime"+index,"Mass Distribution",nbins_combined_hists,0.0,2.);		
 		h_m2denineff_miss_omega_Thetabins_accidsub[i] = new TH1F("h_m2denineff_miss_omega_Thetabins_accidsub"+index,"Mass Distribution",nbins_combined_hists,0.0,2.);		
 	}		
+ 	for(int i =0; i<N_PHI_BINS; ++i) {
+		char asdfasdf[20];
+		sprintf(asdfasdf,"%d",i);
+		TString index = asdfasdf;
+
+		h_m1num_miss_omega_Phibins_intime[i] = new TH1F("h_m1num_miss_omega_Phibins_intime"+index,"Mass Distribution",nbins_combined_hists,0.0,2.);		
+		h_m1num_miss_omega_Phibins_outoftime[i] = new TH1F("h_m1num_miss_omega_Phibins_outoftime"+index,"Mass Distribution",nbins_combined_hists,0.0,2.);		
+		h_m1num_miss_omega_Phibins_accidsub[i] = new TH1F("h_m1num_miss_omega_Phibins_accidsub"+index,"Mass Distribution",nbins_combined_hists,0.0,2.);		
+		h_m1den_miss_omega_Phibins_intime[i] = new TH1F("h_m1den_miss_omega_Phibins_intime"+index,"Mass Distribution",nbins_combined_hists,0.0,2.);		
+		h_m1den_miss_omega_Phibins_outoftime[i] = new TH1F("h_m1den_miss_omega_Phibins_outoftime"+index,"Mass Distribution",nbins_combined_hists,0.0,2.);		
+		h_m1den_miss_omega_Phibins_accidsub[i] = new TH1F("h_m1den_miss_omega_Phibins_accidsub"+index,"Mass Distribution",nbins_combined_hists,0.0,2.);		
+		
+		h_m2num_inv_omega_Phibins_intime[i] = new TH1F("h_m2num_inv_omega_Phibins_intime"+index,"Mass Distribution",nbins_combined_hists,0.0,2.);		
+		h_m2num_inv_omega_Phibins_outoftime[i] = new TH1F("h_m2num_inv_omega_Phibins_outoftime"+index,"Mass Distribution",nbins_combined_hists,0.0,2.);		
+		h_m2num_inv_omega_Phibins_accidsub[i] = new TH1F("h_m2num_inv_omega_Phibins_accidsub"+index,"Mass Distribution",nbins_combined_hists,0.0,2.);		
+		h_m2denineff_miss_omega_Phibins_intime[i] = new TH1F("h_m2denineff_miss_omega_Phibins_intime"+index,"Mass Distribution",nbins_combined_hists,0.0,2.);		
+		h_m2denineff_miss_omega_Phibins_outoftime[i] = new TH1F("h_m2denineff_miss_omega_Phibins_outoftime"+index,"Mass Distribution",nbins_combined_hists,0.0,2.);		
+		h_m2denineff_miss_omega_Phibins_accidsub[i] = new TH1F("h_m2denineff_miss_omega_Phibins_accidsub"+index,"Mass Distribution",nbins_combined_hists,0.0,2.);		
+	}		
 
 	//Show cuts around missing pi0, which helps exclusivity
 	TH1F* h_miss_pi0_all_intime = new TH1F("h_miss_pi0_all_intime","Mass Distribution",nbins_combined_hists,0.0,0.3);		
@@ -483,6 +556,15 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 	TH1F* h_gam1_DeltaTheta = NULL;
 	TH1F* h_gam2_DeltaPhi = NULL;
 	TH1F* h_gam2_DeltaTheta = NULL;
+	TH1F* h_gam1_gam2thr_DeltaPhi = NULL;
+	TH1F* h_gam1_gam2thr_DeltaTheta = NULL;
+	TH1F* h_gam2_gam1thr_DeltaPhi = NULL;
+	TH1F* h_gam2_gam1thr_DeltaTheta = NULL;
+	
+	TH2F* h_gam2_DeltaAngle = NULL;
+	TH2F* h_gam2_gam1thr_DeltaAngle = NULL;
+	TH2F* h_gam2_DeltaAngle_postcuts = NULL;
+	TH2F* h_gam2_gam1thr_DeltaAngle_postcuts = NULL;
 	
 	if(make_thrown_info_hists) {
 		h_gam1_thrown_theta_inrange = new TH1F("h_gam1_thrown_theta_inrange","Thrown Theta",nbins_combined_hists,0.0,15.);	
@@ -499,8 +581,27 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 		h_gam1_DeltaTheta = new TH1F("h_gam1_DeltaTheta","#Delta#phi thrown vs found, gamma1",nbins_combined_hists*10,-180.,180.);	
 		h_gam2_DeltaPhi = new TH1F("h_gam2_DeltaPhi",    "#Delta#phi thrown vs found, gamma2",nbins_combined_hists*10,-180.,180.);	
 		h_gam2_DeltaTheta = new TH1F("h_gam2_DeltaTheta","#Delta#phi thrown vs found, gamma2",nbins_combined_hists*10,-180.,180.);	
+		h_gam1_gam2thr_DeltaPhi = new TH1F("h_gam1_gam2thr_DeltaPhi",    "#Delta#phi thrown vs found, gamma1",nbins_combined_hists*10,-180.,180.);	
+		h_gam1_gam2thr_DeltaTheta = new TH1F("h_gam1_gam2thr_DeltaTheta","#Delta#phi thrown vs found, gamma1",nbins_combined_hists*10,-180.,180.);	
+		h_gam2_gam1thr_DeltaPhi = new TH1F("h_gam2_gam1thr_DeltaPhi",    "#Delta#phi thrown vs found, gamma2",nbins_combined_hists*10,-180.,180.);	
+		h_gam2_gam1thr_DeltaTheta = new TH1F("h_gam2_gam1thr_DeltaTheta","#Delta#phi thrown vs found, gamma2",nbins_combined_hists*10,-180.,180.);	
+	
+		h_gam2_DeltaAngle = new TH2F("h_gam2_DeltaAngle","#Delta#phi thrown vs found, gamma2",nbins_combined_hists,-180.,180.,nbins_combined_hists,-180.,180.);	
+		h_gam2_gam1thr_DeltaAngle = new TH2F("h_gam2_gam1thr_DeltaAngle","#Delta#phi thrown vs found, gamma2",nbins_combined_hists,-180.,180.,nbins_combined_hists,-180.,180.);	
+		h_gam2_DeltaAngle_postcuts = new TH2F("h_gam2_DeltaAngle_postcuts","#Delta#phi thrown vs found, gamma2",nbins_combined_hists,-180.,180.,nbins_combined_hists,-180.,180.);	
+		h_gam2_gam1thr_DeltaAngle_postcuts = new TH2F("h_gam2_gam1thr_DeltaAngle_postcuts","#Delta#phi thrown vs found, gamma2",nbins_combined_hists,-180.,180.,nbins_combined_hists,-20.,20.);	
+	
 	}
 	
+	
+	Int_t last_combo_event=-1;
+	Int_t last_combo_run = -1;
+	Bool_t second_combo_or_more = false;
+	Double_t spectator_showerE_firstcombo = -1;
+	
+	
+	
+	set<Int_t> events_in_run; //For uniqueness checking
 	for(size_t i =0; i<nentries; ++i) {
 		t_in->GetEntry(i);
 		if(i%100000==0) cout << "Entry: "  << i << endl;
@@ -509,7 +610,45 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 			break;			
 		}
 		
+		
+		//Figure out if the current combo in loop is the first for event or not.
+		//If so, grab spectator photon energy E to compare in the future.
+		//If not, look to see whether we should skip this combo or not.
+		if(last_combo_event != Event) second_combo_or_more = false;
+		if(last_combo_event==Event) second_combo_or_more = true;
+		
+		if(!second_combo_or_more) spectator_showerE_firstcombo = Gamma2_E;
+		
+		//HAVE TO SET HERE! (even though these aren't the "last" combo/run value yet.
+		// However there are continue statements that mean I can't put this at the end of the loop...
+		last_combo_event = Event;
+		last_combo_run = Run;
 
+		// if(!second_combo_or_more) cout << endl;
+		// cout << "Run: " << Run << endl;
+		// cout << "Event: " << Event << endl;
+		// cout << "beamE: " << beamE << " rf Delta t: " << rf_deltaT << endl;
+		// cout << "gam2_E: " << Gamma2_E << endl;
+		// cout << "Missing can index 0 Energy: " << MissingCan_E[0] << endl;		
+		// cout << "Difference: " << Gamma2_E-spectator_showerE_firstcombo << endl;
+		
+		//Case 1: skip if spectator DOESN'T match the first combo
+		// if roughly equal... kinematic fit moves them around a little based on beam photon selection, so Gamma2_E will wander a little bit
+		if(WHICH_PHOTON_INDEX==1 && fabs(Gamma2_E-spectator_showerE_firstcombo)>0.01  ) {
+			// cout << "Spectator energy for this combo doesn't match spectator photon for first combo in event, skipping..." << endl;
+			// cout << "Event: " << Event << " total combo " << i << endl;
+			continue;
+		}
+		// if(WHICH_PHOTON_INDEX==1 && fabs(Gamma2_E-spectator_showerE_firstcombo)<0.01 ) {
+			// cout << "Spectator for combo matches..." << endl;
+			// cout << "Event: " << Event << " total combo " << i << endl;
+		// }
+
+		//case 2: if it DOES match, skip it.
+		if(WHICH_PHOTON_INDEX==2 && fabs(Gamma2_E-spectator_showerE_firstcombo)<0.01  ) continue;
+		// if(WHICH_PHOTON_INDEX==2 && fabs(Gamma2_E-spectator_showerE_firstcombo)>0.01  ) {
+		// }
+		
 		TLorentzVector p4_pipl = TLorentzVector(PiPlus_px,PiPlus_py,PiPlus_pz,PiPlus_E);
 		TLorentzVector p4_pim = TLorentzVector(PiMinus_px,PiMinus_py,PiMinus_pz,PiMinus_E);
 		TLorentzVector p4_proton = TLorentzVector(Proton_px,Proton_py,Proton_pz,Proton_E);
@@ -529,6 +668,7 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 			p4_gam1_thr = TLorentzVector(Gamma1_px_th,Gamma1_py_th,Gamma1_pz_th,Gamma1_E_th);
 			p4_gam2_thr = TLorentzVector(Gamma2_px_th,Gamma2_py_th,Gamma2_pz_th,Gamma2_E_th);
 		}	
+		
 				
 		if(USE_THROWN_4VEC) {
 			p4_pipl = p4_pipl_thr;
@@ -539,6 +679,11 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 		}
 				
 		TLorentzVector p4_show = TLorentzVector(MissingCan_Px[0],MissingCan_Py[0],MissingCan_Pz[0],MissingCan_E[0]);
+				
+		Double_t gam1_gam2thr_DeltaTheta = (p4_gam2_thr.Theta()-p4_gam1.Theta())*180/3.14159;
+		Double_t gam1_gam2thr_DeltaPhi = (p4_gam2_thr.Phi()-p4_gam1.Phi())*180/3.14159;
+		Double_t gam2_gam1thr_DeltaTheta = (p4_gam1_thr.Theta()-p4_show.Theta())*180/3.14159;
+		Double_t gam2_gam1thr_DeltaPhi = (p4_gam1_thr.Phi()-p4_show.Phi())*180/3.14159;
 				
 		// Cuts on whole sample here
 		if(Gamma2_E<FOUND_E_MIN) continue;
@@ -554,6 +699,7 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 		Int_t my_theta_bin = -1;
 		if(FCAL_STUDY) my_theta_bin= GetThetaBin25FCAL(p4_gam1.Theta()*180./3.14159);
 		else my_theta_bin = GetThetaBinBCAL(p4_gam1.Theta()*180./3.14159);
+		Int_t my_phi_bin = GetPhiBin(p4_gam1.Phi()*180./3.14159);
 		
 		if(fabs(rf_deltaT)<2) {
 			h_all_missphoton_E_intime->Fill(p4_gam1.E());
@@ -588,6 +734,29 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 		if(p4_gam1.Theta()*180./3.14159 < MISS_THETA_LOCUT || p4_gam1.Theta()*180./3.14159 > MISS_THETA_HICUT) continue;
 		if(p4_gam1.E() < MISS_E_MIN) continue;
 		
+		Bool_t thrown_study_match_flag = true;
+		
+		Double_t smaller_DelPhi = Gamma1_DeltaPhi;
+		// if(fabs(gam2_gam1thr_DeltaPhi) <  fabs(Gamma1_DeltaPhi)) {
+			// smaller_DelPhi = gam1_gam2thr_DeltaPhi;
+		// }
+		Double_t smaller_DelTheta = Gamma1_DeltaTheta;
+		// if(fabs(gam1_gam2thr_DeltaTheta) <  fabs(Gamma1_DeltaTheta)) {
+			// smaller_DelTheta = gam1_gam2thr_DeltaTheta;
+		// }
+		
+		// = (fabs(Gamma2_DeltaPhi)>fabs(gam2_gam1thr_DeltaTheta)) ? gam2_gam1thr_DeltaTheta : Gamma2_DeltaPhi;
+		// Double_t smaller_DelTheta = (fabs(Gamma2_DeltaTheta)>fabs(gam2_gam1thr_DeltaTheta)) ? gam2_gam1thr_DeltaTheta : Gamma2_DeltaTheta;
+			
+		Double_t gam1_miss_phi_deg = p4_gam1.Phi()*180/3.14159;
+		
+		
+		// if(make_thrown_info_hists && fabs(Gamma2_DeltaTheta) > ThrownDeltaTheta_gammastudy && fabs(gam2_gam1thr_DeltaTheta) > ThrownDeltaTheta_gammastudy) thrown_study_match_flag = false;
+		// if(make_thrown_info_hists && fabs(Gamma2_DeltaPhi) > ThrownDeltaPhi_gammastudy && fabs(gam2_gam1thr_DeltaPhi) > ThrownDeltaPhi_gammastudy) thrown_study_match_flag = false;
+		if(make_thrown_info_hists && fabs(smaller_DelTheta) > ThrownDeltaTheta_gammastudy) thrown_study_match_flag = false;
+		if(make_thrown_info_hists && fabs(smaller_DelPhi) > ThrownDeltaPhi_gammastudy) thrown_study_match_flag = false;
+		
+		
 		// if(FCAL_STUDY && p4_gam1.Theta()*180./3.14159 > 13) continue; //Skip photons that point way outside FCAL
 		// if(!FCAL_STUDY && p4_gam1.Theta()*180./3.14159 < 10) continue; //Skip photons that point way outside BCAL
 				
@@ -598,10 +767,12 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 			h_m1den_miss_omega_intime->Fill(RecM_Proton); //One good shower required to get here
 			if(my_E_bin>=0&&my_E_bin<N_E_BINS&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m1den_miss_omega_Ebins_intime[my_E_bin]->Fill(RecM_Proton);
 			if(my_theta_bin>=0&&my_theta_bin<N_THETA_BINS&&p4_gam1.E()>gamma1_miss_Emin) h_m1den_miss_omega_Thetabins_intime[my_theta_bin]->Fill(RecM_Proton);
+			if(my_phi_bin>=0&&my_theta_bin<N_PHI_BINS&&p4_gam1.E()>gamma1_miss_Emin&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m1den_miss_omega_Phibins_intime[my_phi_bin]->Fill(RecM_Proton);
 			if(NFCALCandidates==0&&NBCALCandidates==0) {
 				h_m2denineff_miss_omega_intime->Fill(RecM_Proton);
 				if(my_E_bin>=0&&my_E_bin<N_E_BINS&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m2denineff_miss_omega_Ebins_intime[my_E_bin]->Fill(RecM_Proton);
 				if(my_theta_bin>=0&&my_theta_bin<N_THETA_BINS&&p4_gam1.E()>gamma1_miss_Emin) h_m2denineff_miss_omega_Thetabins_intime[my_theta_bin]->Fill(RecM_Proton);
+				if(my_phi_bin>=0&&my_theta_bin<N_PHI_BINS&&p4_gam1.E()>gamma1_miss_Emin&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m2denineff_miss_omega_Phibins_intime[my_phi_bin]->Fill(RecM_Proton);
 			}
 			if(make_thrown_info_hists) {
 				h_gam1_thrown_theta_inrange->Fill(p4_gam1_thr.Theta()*180./3.14159);
@@ -625,6 +796,11 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 					if(gam1_DeltaTheta<-3.14159) gam1_DeltaTheta+=3.14159; //keep within 180 degrees
 					if(gam1_DeltaTheta> 3.14159) gam1_DeltaTheta-=3.14159; //keep within 180 degrees
 					h_gam1_DeltaTheta->Fill(gam1_DeltaTheta*180./3.14159);
+					
+					h_gam1_gam2thr_DeltaTheta->Fill(gam1_gam2thr_DeltaTheta);
+					h_gam1_gam2thr_DeltaPhi->Fill(gam1_gam2thr_DeltaPhi);
+					h_gam2_gam1thr_DeltaTheta->Fill(gam2_gam1thr_DeltaTheta);
+					h_gam2_gam1thr_DeltaPhi->Fill(gam2_gam1thr_DeltaPhi);
 				}
 				
 				Double_t gam2_DeltaPhi = p4_gam2_thr.Phi()-p4_gam2.Phi();
@@ -636,6 +812,11 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 				if(gam2_DeltaTheta> 3.14159) gam2_DeltaTheta-=3.14159; //keep within 180 degrees
 				h_gam2_DeltaTheta->Fill(gam2_DeltaTheta*180./3.14159);
 				
+				h_gam2_DeltaAngle->Fill(Gamma2_DeltaPhi,Gamma2_DeltaTheta);
+				h_gam2_gam1thr_DeltaAngle->Fill(gam2_gam1thr_DeltaPhi,gam2_gam1thr_DeltaTheta);
+				if(thrown_study_match_flag) h_gam2_DeltaAngle_postcuts->Fill(Gamma2_DeltaPhi,Gamma2_DeltaTheta);
+				if(thrown_study_match_flag) h_gam2_gam1thr_DeltaAngle_postcuts->Fill(gam2_gam1thr_DeltaPhi,gam2_gam1thr_DeltaTheta);
+				
 			}
 		}
 		if(fabs(rf_deltaT)>2) {
@@ -645,10 +826,12 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 			h_m1den_miss_omega_outoftime->Fill(RecM_Proton); //One good shower required to get here
 			if(my_E_bin>=0&&my_E_bin<N_E_BINS&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m1den_miss_omega_Ebins_outoftime[my_E_bin]->Fill(RecM_Proton);
 			if(my_theta_bin>=0&&my_theta_bin<N_THETA_BINS&&p4_gam1.E()>gamma1_miss_Emin) h_m1den_miss_omega_Thetabins_outoftime[my_theta_bin]->Fill(RecM_Proton);
+			if(my_phi_bin>=0&&my_theta_bin<N_PHI_BINS&&p4_gam1.E()>gamma1_miss_Emin&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m1den_miss_omega_Phibins_outoftime[my_phi_bin]->Fill(RecM_Proton);
 			if(NFCALCandidates==0&&NBCALCandidates==0) {
 				h_m2denineff_miss_omega_outoftime->Fill(RecM_Proton);
 				if(my_E_bin>=0&&my_E_bin<N_E_BINS&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m2denineff_miss_omega_Ebins_outoftime[my_E_bin]->Fill(RecM_Proton);
 				if(my_theta_bin>=0&&my_theta_bin<N_THETA_BINS&&p4_gam1.E()>gamma1_miss_Emin) h_m2denineff_miss_omega_Thetabins_outoftime[my_theta_bin]->Fill(RecM_Proton);
+				if(my_phi_bin>=0&&my_theta_bin<N_PHI_BINS&&p4_gam1.E()>gamma1_miss_Emin&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m2denineff_miss_omega_Phibins_outoftime[my_phi_bin]->Fill(RecM_Proton);
 			}
 		}
 		
@@ -675,13 +858,15 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 				h_inv_pi0_all_intime->Fill(twogamma_can_mass[j]); //One good shower required to get here
 				if(twogamma_can_mass[j]>m1_pi0cut_lo&&twogamma_can_mass[j]<m1_pi0cut_hi&&fabs(DeltaPhi_wshow-180.)<m1_DeltaPhiCut) {
 					h_m1num_miss_omega_intime->Fill(RecM_Proton); //One good shower required to get here
-					if(my_E_bin>=0&&my_E_bin<N_E_BINS&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m1num_miss_omega_Ebins_intime[my_E_bin]->Fill(RecM_Proton);
-					if(my_theta_bin>=0&&my_theta_bin<N_THETA_BINS&&p4_gam1.E()>gamma1_miss_Emin) h_m1num_miss_omega_Thetabins_intime[my_theta_bin]->Fill(RecM_Proton);
+					if(thrown_study_match_flag&&my_E_bin>=0&&my_E_bin<N_E_BINS&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m1num_miss_omega_Ebins_intime[my_E_bin]->Fill(RecM_Proton);
+					if(thrown_study_match_flag&&my_theta_bin>=0&&my_theta_bin<N_THETA_BINS&&p4_gam1.E()>gamma1_miss_Emin) h_m1num_miss_omega_Thetabins_intime[my_theta_bin]->Fill(RecM_Proton);
+					if(thrown_study_match_flag&&my_phi_bin>=0&&my_theta_bin<N_PHI_BINS&&p4_gam1.E()>gamma1_miss_Emin&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m1num_miss_omega_Phibins_intime[my_phi_bin]->Fill(RecM_Proton);
 				}
 				if(twogamma_can_mass[j]<m1_pi0cut_lo) h_inv_omega_badpi0_intime->Fill(threepi_can_mass[j]); //One good shower required to get here
 				h_m2num_inv_omega_intime->Fill(threepi_can_mass[j]); //One good shower required to get here
 				if(my_E_bin>=0&&my_E_bin<N_E_BINS&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m2num_inv_omega_Ebins_intime[my_E_bin]->Fill(RecM_Proton);
 				if(my_theta_bin>=0&&my_theta_bin<N_THETA_BINS&&p4_gam1.E()>gamma1_miss_Emin) h_m2num_inv_omega_Thetabins_intime[my_theta_bin]->Fill(RecM_Proton);
+				if(my_phi_bin>=0&&my_theta_bin<N_PHI_BINS&&p4_gam1.E()>gamma1_miss_Emin&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m2num_inv_omega_Phibins_intime[my_phi_bin]->Fill(RecM_Proton);
 				h_missing_omega_4scale_intime->Fill(RecM_Proton); //One good shower required to get here
 				if(twogamma_can_mass[j]>m1_pi0cut_lo&&twogamma_can_mass[j]<m1_pi0cut_hi&&fabs(DeltaPhi_wshow-180.)<m1_DeltaPhiCut) h2_MM_vs_invm_pi0cuts_intime->Fill(RecM_Proton,threepi_can_mass[j]); //One good shower required to get here
 				h2_MM_vs_invm_loose_intime->Fill(RecM_Proton,threepi_can_mass[j]); //One good shower required to get here
@@ -691,18 +876,23 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 				h_inv_pi0_all_outoftime->Fill(twogamma_can_mass[j]); //One good shower required to get here
 				if(twogamma_can_mass[j]>m1_pi0cut_lo&&twogamma_can_mass[j]<m1_pi0cut_hi&&fabs(DeltaPhi_wshow-180.)<m1_DeltaPhiCut) {
 					h_m1num_miss_omega_outoftime->Fill(RecM_Proton); //One good shower required to get here
-					if(my_E_bin>=0&&my_E_bin<N_E_BINS&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m1num_miss_omega_Ebins_outoftime[my_E_bin]->Fill(RecM_Proton);
-					if(my_theta_bin>=0&&my_theta_bin<N_THETA_BINS&&p4_gam1.E()>gamma1_miss_Emin) h_m1num_miss_omega_Thetabins_outoftime[my_theta_bin]->Fill(RecM_Proton);
+					if(thrown_study_match_flag&&my_E_bin>=0&&my_E_bin<N_E_BINS&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m1num_miss_omega_Ebins_outoftime[my_E_bin]->Fill(RecM_Proton);
+					if(thrown_study_match_flag&&my_theta_bin>=0&&my_theta_bin<N_THETA_BINS&&p4_gam1.E()>gamma1_miss_Emin) h_m1num_miss_omega_Thetabins_outoftime[my_theta_bin]->Fill(RecM_Proton);
+					if(thrown_study_match_flag&&my_phi_bin>=0&&my_theta_bin<N_PHI_BINS&&p4_gam1.E()>gamma1_miss_Emin&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m1num_miss_omega_Phibins_outoftime[my_phi_bin]->Fill(RecM_Proton);
 				}
 				if(twogamma_can_mass[j]<m1_pi0cut_lo) h_inv_omega_badpi0_outoftime->Fill(threepi_can_mass[j]); //One good shower required to get here
 				h_m2num_inv_omega_outoftime->Fill(threepi_can_mass[j]); //One good shower required to get here
 				if(my_E_bin>=0&&my_E_bin<N_E_BINS&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m2num_inv_omega_Ebins_outoftime[my_E_bin]->Fill(RecM_Proton);
 				if(my_theta_bin>=0&&my_theta_bin<N_THETA_BINS&&p4_gam1.E()>gamma1_miss_Emin) h_m2num_inv_omega_Thetabins_outoftime[my_theta_bin]->Fill(RecM_Proton);
+				if(my_phi_bin>=0&&my_theta_bin<N_PHI_BINS&&p4_gam1.E()>gamma1_miss_Emin&&p4_gam1.Theta()*180./3.14159>gamma1_miss_lotheta&&p4_gam1.Theta()*180./3.14159<gamma1_miss_hitheta) h_m2num_inv_omega_Phibins_outoftime[my_phi_bin]->Fill(RecM_Proton);
 				h_missing_omega_4scale_outoftime->Fill(RecM_Proton); //One good shower required to get here
 				if(twogamma_can_mass[j]>m1_pi0cut_lo&&twogamma_can_mass[j]<m1_pi0cut_hi&&fabs(DeltaPhi_wshow-180.)<m1_DeltaPhiCut) h2_MM_vs_invm_pi0cuts_outoftime->Fill(RecM_Proton,threepi_can_mass[j]); //One good shower required to get here
 				h2_MM_vs_invm_loose_outoftime->Fill(RecM_Proton,threepi_can_mass[j]); //One good shower required to get here
 			}
 		}
+		
+		
+		
 		
 	}
 	
@@ -748,6 +938,7 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 	h_miss_pi0_postcuts_outoftime->Sumw2();
 	
 	
+	
 	Double_t Delta_t_scalefactor = 1. / (2*NBeamBunchesOutoftime);
 	
 	
@@ -782,6 +973,8 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 	h_gamma2_E_all_accidsub->Add(h_gamma2_E_all_intime,h_gamma2_E_all_outoftime,1.,-1*Delta_t_scalefactor);
 	h_gamma2_E_vs_theta_all_accidsub->Add(h_gamma2_E_vs_theta_all_intime,h_gamma2_E_vs_theta_all_outoftime,1.,-1*Delta_t_scalefactor);
 	
+	
+	
  	for(int i =0; i<N_E_BINS; ++i) {
 		h_m1num_miss_omega_Ebins_intime[i]->Sumw2();
 		h_m1num_miss_omega_Ebins_outoftime[i]->Sumw2();
@@ -813,6 +1006,23 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 		h_m2num_inv_omega_Thetabins_accidsub[i]->Add(h_m2num_inv_omega_Thetabins_intime[i],h_m2num_inv_omega_Thetabins_outoftime[i],1.,-1*Delta_t_scalefactor);
 		h_m2denineff_miss_omega_Thetabins_accidsub[i]->Add(h_m2denineff_miss_omega_Thetabins_intime[i],h_m2denineff_miss_omega_Thetabins_outoftime[i],1.,-1*Delta_t_scalefactor);
 	}	
+ 	for(int i =0; i<N_PHI_BINS; ++i) {
+		h_m1num_miss_omega_Phibins_intime[i]->Sumw2();
+		h_m1num_miss_omega_Phibins_outoftime[i]->Sumw2();
+		h_m1den_miss_omega_Phibins_intime[i]->Sumw2();
+		h_m1den_miss_omega_Phibins_outoftime[i]->Sumw2();
+		h_m2num_inv_omega_Phibins_intime[i]->Sumw2();
+		h_m2num_inv_omega_Phibins_outoftime[i]->Sumw2();
+		h_m2denineff_miss_omega_Phibins_intime[i]->Sumw2();
+		h_m2denineff_miss_omega_Phibins_outoftime[i]->Sumw2();
+		
+		h_m1num_miss_omega_Phibins_accidsub[i]->Add(h_m1num_miss_omega_Phibins_intime[i],h_m1num_miss_omega_Phibins_outoftime[i],1.,-1*Delta_t_scalefactor);
+		h_m1den_miss_omega_Phibins_accidsub[i]->Add(h_m1den_miss_omega_Phibins_intime[i],h_m1den_miss_omega_Phibins_outoftime[i],1.,-1*Delta_t_scalefactor);
+		h_m2num_inv_omega_Phibins_accidsub[i]->Add(h_m2num_inv_omega_Phibins_intime[i],h_m2num_inv_omega_Phibins_outoftime[i],1.,-1*Delta_t_scalefactor);
+		h_m2denineff_miss_omega_Phibins_accidsub[i]->Add(h_m2denineff_miss_omega_Phibins_intime[i],h_m2denineff_miss_omega_Phibins_outoftime[i],1.,-1*Delta_t_scalefactor);
+	}	
+	
+
 	
 	TFile* outfile = new TFile( str_outfile, "RECREATE" );
 	outfile->cd();
@@ -852,6 +1062,7 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 	h_gamma2_E_all_accidsub->Write();
 	h_gamma2_E_vs_theta_all_accidsub->Write();
 
+	
 	for(int i =0; i<N_E_BINS; ++i) h_m1num_miss_omega_Ebins_accidsub[i]->Write();
 	for(int i =0; i<N_E_BINS; ++i) h_m1den_miss_omega_Ebins_accidsub[i]->Write();
 	for(int i =0; i<N_E_BINS; ++i) h_m2num_inv_omega_Ebins_accidsub[i]->Write();
@@ -860,6 +1071,11 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 	for(int i =0; i<N_THETA_BINS; ++i) h_m1den_miss_omega_Thetabins_accidsub[i]->Write();
 	for(int i =0; i<N_THETA_BINS; ++i) h_m2num_inv_omega_Thetabins_accidsub[i]->Write();
 	for(int i =0; i<N_THETA_BINS; ++i) h_m2denineff_miss_omega_Thetabins_accidsub[i]->Write();
+	for(int i =0; i<N_PHI_BINS; ++i) h_m1num_miss_omega_Phibins_accidsub[i]->Write();
+	for(int i =0; i<N_PHI_BINS; ++i) h_m1den_miss_omega_Phibins_accidsub[i]->Write();
+	for(int i =0; i<N_PHI_BINS; ++i) h_m2num_inv_omega_Phibins_accidsub[i]->Write();
+	for(int i =0; i<N_PHI_BINS; ++i) h_m2denineff_miss_omega_Phibins_accidsub[i]->Write();
+	
 	
 	if(make_thrown_info_hists) {
 		h_gam1_thrown_theta_inrange->Write();
@@ -876,7 +1092,18 @@ Int_t MakeOmegaHists(TString str_infile, TString str_outfile, Bool_t make_thrown
 		h_gam1_DeltaTheta->Write();
 		h_gam2_DeltaPhi->Write();
 		h_gam2_DeltaTheta->Write();
+		h_gam1_gam2thr_DeltaPhi->Write();
+		h_gam1_gam2thr_DeltaTheta->Write();
+		h_gam2_gam1thr_DeltaPhi->Write();
+		h_gam2_gam1thr_DeltaTheta->Write();
+		
+		h_gam2_DeltaAngle->Write();
+		h_gam2_gam1thr_DeltaAngle->Write();
+		h_gam2_DeltaAngle_postcuts->Write();
+		h_gam2_gam1thr_DeltaAngle_postcuts->Write();
 	}
+	
+	
 	
 	
 	outfile->Close();


### PR DESCRIPTION
Updates to FCAL photon "tag-and-probe" study with code located in EfficiencyUtilities/NeutralUtilities. Add as a function of phi, along with a few other minor tweaks.