### PR TITLE
expand histogram dimentions in y (detla t adc/tdc) to be less sensiti…

### DIFF
--- a/TOF_calib/src/doadctimeoffsets.C
+++ b/TOF_calib/src/doadctimeoffsets.C
@@ -44,15 +44,15 @@ void doadctimeoffsets(int Run){
   BARS_PER_PLANE = NPMTS/4;
   PMTS_PER_PLANE = NPMTS/2;
  
-  double LOLIM = -10.;
-  double HILIM = 10.;
+  double LOLIM = -20.;
+  double HILIM = 20.;
   
   TDiff  = new TH2D("TDiff",  "TDC_T - ADC_T", 
 		    NumPMTMax, 0., (double)NumPMTMax, 
-		    200, LOLIM, HILIM);
+		    400, LOLIM, HILIM);
   TDiffF = new TH2D("TDiffF","TDC_T - ADC_T", 
 		    NumPMTMax, 0., (double)NumPMTMax, 
-		    200, LOLIM*10., HILIM*10.);
+		    400, LOLIM*5., HILIM*5.);
   
   char fnam[128];
   char ROOTFILE[128];


### PR DESCRIPTION
…ve to larger

variations in time differences leading the fit to fail.
sometimes the time difference was larger than 10ns which caused the fit to fail.