### PR TITLE
get rcdb database from environment in launch scripts

### DIFF
--- a/launch_scripts/launch/launch.py
+++ b/launch_scripts/launch/launch.py
@@ -352,7 +352,7 @@ def main(argv):
 	INDATA_TOPDIR = config_dict["INDATA_TOPDIR"] if ("INDATA_TOPDIR" in config_dict) else ""
 
 	# GET THE LIST OF GOOD RUNS
-	db = rcdb.RCDBProvider("mysql://rcdb@hallddb/rcdb")
+	db = rcdb.RCDBProvider(os.environ.get('RCDB_CONNECTION'))
 	good_runs = []
 	if(VERBOSE == True):
 		print("RCDB_QUERY = " + RCDB_QUERY)

--- a/launch_scripts/launch/launch_one_job_per_run.py
+++ b/launch_scripts/launch/launch_one_job_per_run.py
@@ -361,7 +361,7 @@ def main(argv):
 	INDATA_TOPDIR = config_dict["INDATA_TOPDIR"] if ("INDATA_TOPDIR" in config_dict) else ""
 
 	# GET THE LIST OF GOOD RUNS
-	db = rcdb.RCDBProvider("mysql://rcdb@hallddb/rcdb")
+	db = rcdb.RCDBProvider(os.environ.get('RCDB_CONNECTION'))
 	good_runs = []
 	if(VERBOSE == True):
 		print("RCDB_QUERY = " + RCDB_QUERY)

--- a/launch_scripts/process/process_new_offline_data.py
+++ b/launch_scripts/process/process_new_offline_data.py
@@ -624,7 +624,7 @@ def main():
     # try to connect to RCDB
     rcdb_conn = None
     try:
-        rcdb_conn = rcdb.RCDBProvider("mysql://rcdb@hallddb/rcdb")
+        rcdb_conn = rcdb.RCDBProvider(os.environ.get('RCDB_CONNECTION'))
     except:
         e = sys.exc_info()[0]
         print("Could not connect to RCDB: " + str(e))

--- a/launch_scripts/process/process_run_conditions.py
+++ b/launch_scripts/process/process_run_conditions.py
@@ -403,7 +403,7 @@ def main(argv):
 
     # if we don't have a start time, grab it from the RCDB
     if 'start_time' not in run_properties:
-        rcdb_conn = rcdb.RCDBProvider("mysql://rcdb@hallddb/rcdb")
+        rcdb_conn = rcdb.RCDBProvider(os.environ.get('RCDB_CONNECTION'))
         run_properties['start_time'] = rcdb_conn.get_run(run_number).start_time
 
     if VERBOSE:


### PR DESCRIPTION
The standard GlueX environment connects either to rcdb or rcdb2 depending on the software version. This is necessary because the  required a schema change of the RCDB.