### PR TITLE
flatten rcdb silent fail fix

### DIFF
--- a/FlattenForFSRoot/Makefile
+++ b/FlattenForFSRoot/Makefile
@@ -1,7 +1,27 @@
 #! gnumake
 
-ROOTFLAGS     = $(shell root-config --cflags)
-ROOTLIBS      = $(shell root-config --libs) -lMinuit -lMathCore
+unexport CPATH
+
+CXX = $(CONDA_PREFIX)/bin/x86_64-conda-linux-gnu-g++
+
+SYSROOT = $(CONDA_PREFIX)/x86_64-conda-linux-gnu/sysroot
+GCCVER = $(shell $(CXX) -dumpfullversion)
+
+GCCLIB = $(CONDA_PREFIX)/lib/gcc/x86_64-conda-linux-gnu/$(GCCVER)
+CXXINC = $(GCCLIB)/include/c++
+
+
+SYSROOTFLAGS = --sysroot=$(SYSROOT) -nostdinc \
+	       -isystem $(CXXINC) \
+	       -isystem $(CXXINC)/x86_64-conda-linux-gnu \
+	       -isystem $(CXXINC)/backward \
+	       -isystem $(GCCLIB)/include \
+	       -isystem $(GCCLIB)/include-fixed \
+	       -isystem $(SYSROOT)/usr/include \
+	       -isystem $(SYSROOT)/usr/include/x86_64-conda-linux-gnu
+
+ROOTFLAGS     = $(shell $(CONDA_PREFIX)/bin/root-config --cflags)
+ROOTLIBS      = $(shell $(CONDA_PREFIX)/bin/root-config --libs) -lMinuit -lMathCore
 
 EXE_SRCFILES := $(wildcard *.cc)
 EXE_EXEFILES := $(foreach file,$(EXE_SRCFILES),$(file:.cc=))
@@ -9,8 +29,8 @@ EXE_EXEFILES := $(foreach file,$(EXE_SRCFILES),$(file:.cc=))
 default: $(EXE_EXEFILES)
 
 %: %.cc
-	g++  $(ROOTFLAGS) $(MYINCLUDES) -c -o $*.o $*.cc
-	g++  $(ROOTFLAGS) $(MYINCLUDES) $(ROOTLIBS) $*.o -o $*
+	$(CXX)  $(SYSROOTFLAGS) $(ROOTFLAGS) $(MYINCLUDES) -c -o $*.o $*.cc
+	$(CXX)  $(SYSROOTFLAGS) $(ROOTFLAGS) $(MYINCLUDES) $(ROOTLIBS) $*.o -o $*
 
 
 clean:

--- a/FlattenForFSRoot/flatten.cc
+++ b/FlattenForFSRoot/flatten.cc
@@ -2269,31 +2269,38 @@ bool GetPolarizationAngle(int runNumber, int& polarizationAngle)
   locCommandStream << "rcnd " << runNumber << " polarization_angle";
   FILE* locInputFile = gSystem->OpenPipe(locCommandStream.str().c_str(), "r");
   if(locInputFile == NULL){
-    std::cerr << "\nFATAL: rcnd returned no output.\n"
-	      << "       Command: " << localCommandStream.str() << "\n\n";
+    std::cerr << "FATAL: Could not run rcnd (OpenPipe failed).  Is RCDB set up?\n"
+	      << "       Command was: " << locCommandStream.str() << "\n";
     std::exit(2);
   }
 
-
-  //get the first line
+  // read the first line of stdout
   char buff[1024];
-  if(fgets(buff, sizeof(buff), locInputFile) == NULL)
-    return 0;
-  istringstream locStringStream(buff);
+  if(!fgets(buff, sizeof(buff), locInputFile)){
+    gSystem->ClosePipe(locInputFile);
+    std::cerr << "FATAL: rcnd produced no stdout.\n";
+    std::exit(2);
+  }
 
-  //Close the pipe
-  gSystem->ClosePipe(locInputFile);
+  int rc = gSystem->ClosePipe(locInputFile);
+  if(rc != 0){
+    std::cerr << "FATAL: rcnd exited nonzero (" << rc << ").\n"
+	      << "        Command was: " << locCommandStream.str() << "\n"
+	      << " First line was: " << buff;
+    std::exit(2);
+  }
 
-  //extract it
-  string locPolarizationAngleString;
-  if(!(locStringStream >> locPolarizationAngleString))
-    return false;
+  int polTmp;
+  std::istringstream iss(buff);
+  if(!(iss >> polTmp)){
+    std::cerr << "FATAL: rcnd output not numeric: " << buff << "\n";
+    std::exit(2);
+  }
 
-  // convert string to integer
-  polarizationAngle = atoi(locPolarizationAngleString.c_str());
-  // amorphous runs have the value -1
-  if (polarizationAngle == -1)
+  polarizationAngle = polTmp;
+  if(polarizationAngle == -1)
     return false;
 
   return true;
+
 }

--- a/FlattenForFSRoot/flatten.cc
+++ b/FlattenForFSRoot/flatten.cc
@@ -2268,8 +2268,12 @@ bool GetPolarizationAngle(int runNumber, int& polarizationAngle)
   ostringstream locCommandStream;
   locCommandStream << "rcnd " << runNumber << " polarization_angle";
   FILE* locInputFile = gSystem->OpenPipe(locCommandStream.str().c_str(), "r");
-  if(locInputFile == NULL)
-    return false;
+  if(locInputFile == NULL){
+    std::cerr << "\nFATAL: rcnd returned no output.\n"
+	      << "       Command: " << localCommandStream.str() << "\n\n";
+    std::exit(2);
+  }
+
 
   //get the first line
   char buff[1024];


### PR DESCRIPTION
When running `flatten` outside ifarm with flag `-usePolarization` trees are made even if `rcdb` is not present on that server, i.e. `flatten` silently fails.    A connection to rcdb is essential as that is where polarization information is stored.  Therefore an error should appear if it is not setup right.  This fix throws an error if either `rcdb` is not found or if the environment variable RCDB_CONNECTION is not set.  NOTE: Typically RCDB_CONNECTION is automatically set when sourcing the GlueX environment; so that error is more likely to appear when working outside `ifarm`.