### PR TITLE
Fix Uninitialized Polarization Variable in flatten.cc

### DIFF
--- a/FlattenForFSRoot/flatten.cc
+++ b/FlattenForFSRoot/flatten.cc
@@ -1101,6 +1101,7 @@ int main(int argc, char** argv){
   Long64_t gInNEntries = gInTree->GetEntries();
   TString gInFileName("");
   int currPol = -999; // hold polarization value for the entire run (assuming one run per tree!)
+  bool triedPolarizationInitialize=false;
   cout << "LOOPING OVER " << gInNEntries << " ENTRIES..." << endl;
   for (Long64_t iEntry = 0; iEntry < gInNEntries; iEntry++){
     if ((iEntry+1) % 10000 == 0) cout << "entry = " << iEntry+1 << "  (" << (100.0*(iEntry+1))/gInNEntries << " percent)" << endl;
@@ -1287,9 +1288,10 @@ int main(int argc, char** argv){
       outRunNumber       = inRunNumber;
       outEventNumber     = inEventNumber;
       if(gUsePolarization) {
-        if(iEntry==0) {
+        if(!triedPolarizationInitialize) {
           GetPolarizationAngle(inRunNumber, currPol);
           outPolarization = currPol;
+          triedPolarizationInitialize=true;
         } else {
             if(currPol==-999){
               std::cerr << "FATAL: unable to find polarization info!!" << endl;

--- a/FlattenForFSRoot/flatten.cc
+++ b/FlattenForFSRoot/flatten.cc
@@ -1287,7 +1287,7 @@ int main(int argc, char** argv){
       outRunNumber       = inRunNumber;
       outEventNumber     = inEventNumber;
       if(gUsePolarization) {
-        if(currPol==-999) {
+        if(iEntry==0) {
           if(GetPolarizationAngle(inRunNumber, currPol)) {
             outPolarization = currPol;
           } else {
@@ -1295,6 +1295,10 @@ int main(int argc, char** argv){
             currPol = -1;
           }
         } else {
+	  if(currPol==-999){
+	    cout << "FATAL: unable to find polarization info!!" << endl;
+	    exit(0);
+	  }
           outPolarization = currPol;
         }
       }

--- a/FlattenForFSRoot/flatten.cc
+++ b/FlattenForFSRoot/flatten.cc
@@ -1100,7 +1100,7 @@ int main(int argc, char** argv){
 
   Long64_t gInNEntries = gInTree->GetEntries();
   TString gInFileName("");
-  int currPol; // hold polarization value for the entire run (assuming one run per tree!)
+  int currPol = -999; // hold polarization value for the entire run (assuming one run per tree!)
   cout << "LOOPING OVER " << gInNEntries << " ENTRIES..." << endl;
   for (Long64_t iEntry = 0; iEntry < gInNEntries; iEntry++){
     if ((iEntry+1) % 10000 == 0) cout << "entry = " << iEntry+1 << "  (" << (100.0*(iEntry+1))/gInNEntries << " percent)" << endl;
@@ -1287,11 +1287,12 @@ int main(int argc, char** argv){
       outRunNumber       = inRunNumber;
       outEventNumber     = inEventNumber;
       if(gUsePolarization) {
-        if(iEntry==0) {
+        if(currPol==-999) {
           if(GetPolarizationAngle(inRunNumber, currPol)) {
             outPolarization = currPol;
           } else {
             outPolarization = -1;
+	    currPol = -1;
           }
         } else {
           outPolarization = currPol;

--- a/FlattenForFSRoot/flatten.cc
+++ b/FlattenForFSRoot/flatten.cc
@@ -1289,7 +1289,7 @@ int main(int argc, char** argv){
       if(gUsePolarization) {
         if(iEntry==0) {
           GetPolarizationAngle(inRunNumber, currPol);
-	  outPolarization = currPol;
+          outPolarization = currPol;
         } else {
 	  if(currPol==-999){
 	    std::cerr << "FATAL: unable to find polarization info!!" << endl;

--- a/FlattenForFSRoot/flatten.cc
+++ b/FlattenForFSRoot/flatten.cc
@@ -1291,10 +1291,10 @@ int main(int argc, char** argv){
           GetPolarizationAngle(inRunNumber, currPol);
           outPolarization = currPol;
         } else {
-	  if(currPol==-999){
-	    std::cerr << "FATAL: unable to find polarization info!!" << endl;
-	    exit(0);
-	  }
+            if(currPol==-999){
+              std::cerr << "FATAL: unable to find polarization info!!" << endl;
+              exit(0);
+            }
           outPolarization = currPol;
         }
       }

--- a/FlattenForFSRoot/flatten.cc
+++ b/FlattenForFSRoot/flatten.cc
@@ -1292,7 +1292,7 @@ int main(int argc, char** argv){
             outPolarization = currPol;
           } else {
             outPolarization = -1;
-	    currPol = -1;
+            currPol = -1;
           }
         } else {
           outPolarization = currPol;

--- a/FlattenForFSRoot/flatten.cc
+++ b/FlattenForFSRoot/flatten.cc
@@ -1288,15 +1288,11 @@ int main(int argc, char** argv){
       outEventNumber     = inEventNumber;
       if(gUsePolarization) {
         if(iEntry==0) {
-          if(GetPolarizationAngle(inRunNumber, currPol)) {
-            outPolarization = currPol;
-          } else {
-            outPolarization = -1;
-            currPol = -1;
-          }
+          GetPolarizationAngle(inRunNumber, currPol);
+	  outPolarization = currPol;
         } else {
 	  if(currPol==-999){
-	    cout << "FATAL: unable to find polarization info!!" << endl;
+	    std::cerr << "FATAL: unable to find polarization info!!" << endl;
 	    exit(0);
 	  }
           outPolarization = currPol;
@@ -2273,13 +2269,17 @@ bool GetPolarizationAngle(int runNumber, int& polarizationAngle)
   ostringstream locCommandStream;
   locCommandStream << "rcnd " << runNumber << " polarization_angle";
   FILE* locInputFile = gSystem->OpenPipe(locCommandStream.str().c_str(), "r");
-  if(locInputFile == NULL)
-    return false;
-
+  if(locInputFile == NULL){
+    std::cerr << "FATAL: Could not run rcnd. Is RCDB set up? " << endl;
+    exit(2);
+  }
   //get the first line
   char buff[1024];
-  if(fgets(buff, sizeof(buff), locInputFile) == NULL)
-    return 0;
+  if(fgets(buff, sizeof(buff), locInputFile) == NULL){
+    std::cerr << "FATAL: rcnd produced no stdout" << endl;
+    exit(2);
+  }
+
   istringstream locStringStream(buff);
 
   //Close the pipe
@@ -2287,8 +2287,10 @@ bool GetPolarizationAngle(int runNumber, int& polarizationAngle)
 
   //extract it
   string locPolarizationAngleString;
-  if(!(locStringStream >> locPolarizationAngleString))
-    return false;
+  if(!(locStringStream >> locPolarizationAngleString)){
+    std::cerr << "FATAL: unable to read PolarizationAngle from istringstream" << endl;
+    exit(2);
+  }
 
   // convert string to integer
   polarizationAngle = atoi(locPolarizationAngleString.c_str());


### PR DESCRIPTION
This pull request contains a fix for the PolarizationAngle variable in FlattenForFSRoot. It properly initializes the variable and fails with an error message if it can't find the polarization information. 
