### PR TITLE
FlattenForFSRoot: add -numericIndices option for decay products

### DIFF
--- a/FlattenForFSRoot/Documentation/GlueXFSRootFormat.tex
+++ b/FlattenForFSRoot/Documentation/GlueXFSRootFormat.tex
@@ -123,6 +123,26 @@ Different types of four-momenta and vertices are distinguished using prefixes.  
 
 Different particles are differentiated using the postfix {\tt P(n)}, where {\tt (n)} is the number of the particle in the ordered list.  Four-momenta and vertices for secondaries originating from particle~{\tt (n)}, such as the two $\gamma$'s from a $\pi^0$, are recorded using {\tt P(n)a} and {\tt P(n)b}, where the ordering follows the same conventions as above, or, in the case of identical daughter particles, no ordering is assumed.  As two examples: in the process $\gamma p \to\pi^+\pi^-J/\psi p; J/\psi\to\mu^+\mu^-$, the raw energy of the $\pi^+$ is given by {\tt REnP4}; and in the process $\gamma p \to \pi^+\pi^-J/\psi p; J/\psi\to\pi^+\pi^-\pi^0$, the y-momentum of a photon from the $\pi^0$ decay, after the kinematic fit, is given by {\tt PyP6b}.
 
+\subsection{Numeric indices for decay products}
+\label{sec:nt:numericindices}
+
+The argument {\tt -numericIndices 1} replaces the {\tt a}/{\tt b} postfixes with plain numbers.  Decay products are numbered consecutively \emph{after} all of the primaries, so the primaries keep exactly the indices they have by default and only the decay products are renamed.  Writing a tree both ways therefore produces the same set of variables under two names, with identical contents.
+
+For example, in the final state $\Lambda\,p\,K^+\pi^+\pi^-\pi^0$ with $\Lambda\to p\pi^-$ and $\pi^0\to\gamma\gamma$, the default indices are
+\begin{verbatim}
+    1 (Lambda)  1a (p)  1b (pi-)  2 (p)  3 (K+)  4 (pi+)  5 (pi-)
+    6 (pi0)  6a (gamma)  6b (gamma)
+\end{verbatim}
+and with {\tt -numericIndices 1} they become
+\begin{verbatim}
+    1 (Lambda)  7 (p)  8 (pi-)  2 (p)  3 (K+)  4 (pi+)  5 (pi-)
+    6 (pi0)  9 (gamma)  10 (gamma)
+\end{verbatim}
+
+With this option every particle in the tree is reachable as {\tt P1}~$\ldots$~{\tt P(N)} for {\tt N} particles in total.  This matters for code that reads the tree by looping over an index range rather than by name --- for example the {\tt FSRootDataReader} classes in {\tt halld\_sim}, which build branch names as {\tt EnP1}~$\ldots$~{\tt EnP(N)} and cannot reach an {\tt a}/{\tt b} postfix at all.  Because the primaries come first, asking such a reader for the first {\tt N} particles selects the primaries and then the decay products in order.
+
+The default remains the {\tt a}/{\tt b} convention, so existing trees and macros are unaffected.  Note that the two conventions cannot be mixed within one tree, and that the mode-level tooling in the {\tt FSRoot} package (for example the {\tt EnP[pi+]} expansions, which are built from the mode code) only ever refers to primaries; those expansions are unchanged by this option.
+
 
 
 

--- a/FlattenForFSRoot/flatten.cc
+++ b/FlattenForFSRoot/flatten.cc
@@ -82,6 +82,11 @@ int main(int argc, char** argv){
   cout << "           -dirc [include PID information from the DIRC if available? 0 or 1] (default: 0)" << endl;
   cout << "           -flattenpi0 [flatten pi0s to just gamma gamma? 0 or 1]   (default: 0)" << endl;
   cout << "           -flatteneta [flatten etas to just gamma gamma? 0 or 1]   (default: 0)" << endl;
+  cout << "           -numericIndices [index decay products numerically? 0 or 1] (default: 0)" << endl;
+  cout << "                   (0: decay products of particle (n) are P(n)a, P(n)b;" << endl;
+  cout << "                    1: decay products are numbered after all primaries," << endl;
+  cout << "                       so primary indices are unchanged and every particle" << endl;
+  cout << "                       is P1..PN -- see Documentation/GlueXFSRootFormat.pdf)" << endl;
   cout << "           -addUnusedNeutrals  [include 4-vectors for unused neutrals? " << endl;
   cout << "                                0 or number to include] (default: 0)" << endl;  
   cout << "           -combos [ if there are multiple combos in an event with the same chi2, then " << endl;
@@ -137,6 +142,7 @@ int main(int argc, char** argv){
   bool gUseDIRC = false;
   bool gFlattenpi0 = false;
   bool gFlatteneta = false;
+  bool gNumericIndices = false;
   int gAddUnusedNeutrals = 0;
   int gCombos = 0;
   bool gMCChecks = true;
@@ -149,6 +155,7 @@ int main(int argc, char** argv){
         ||(argi == "-chi2")||(argi == "-RFDeltaT")||(argi == "-shQuality")||(argi == "-massWindows")
         ||(argi == "-numUnusedTracks")||(argi == "-usePolarization")||(argi == "-numUnusedNeutrals")
         ||(argi == "-mcChecks")||(argi == "-addPID")||(argi == "-dirc")||(argi == "-flattenpi0")||(argi == "-flatteneta")
+        ||(argi == "-numericIndices")
         ||(argi=="-addUnusedNeutrals")||(argi == "-combos")
         ||(argi == "-numNeutralHypos")||(argi == "-safe")||(argi == "-print")){
       flag = argi;
@@ -171,6 +178,7 @@ int main(int argc, char** argv){
     if (flag == "-dirc"){   if( argi == "1") gUseDIRC = true; }
     if (flag == "-flattenpi0"){ if (argi == "1") gFlattenpi0 = true; }
     if (flag == "-flatteneta"){ if (argi == "1") gFlatteneta = true; }
+    if (flag == "-numericIndices"){ if (argi == "1") gNumericIndices = true; }
     if (flag == "-addUnusedNeutrals"){ gAddUnusedNeutrals = atoi(argi); }
     if (flag == "-combos"){ gCombos = atoi(argi); }
     if (flag == "-mcChecks"){ if (argi == "0") gMCChecks = false; }
@@ -213,6 +221,7 @@ int main(int argc, char** argv){
   cout << "  use DIRC?              " << gUseDIRC << endl;
   cout << "  flatten pi0s?          " << gFlattenpi0 << endl;
   cout << "  flatten etas?          " << gFlatteneta << endl;
+  cout << "  numeric decay indices? " << gNumericIndices << endl;
   cout << "  add unused neutrals?   " << gAddUnusedNeutrals << endl;
   cout << "  combos option:         " << gCombos << endl;
   cout << "  MC checks?             " << gMCChecks << endl;
@@ -621,12 +630,22 @@ int main(int argc, char** argv){
   map<TString, int> gMapGlueXNameToParticleIndex;
   {
     int particleIndex = 0;
+    // in the numeric scheme, decay products are numbered sequentially after
+    // all of the primaries, so the primaries keep the indices they have in
+    // the default scheme and only the decay products are renamed
+    int decayIndex = gOrderedParticleNames.size();
     for (unsigned int im = 0; im < gOrderedParticleNames.size(); im++){
     for (unsigned int id = 0; id < gOrderedParticleNames[im].size(); id++){
       TString name = gOrderedParticleNames[im][id];
-      TString fsIndex("");  fsIndex += (im+1);
-      if (id == 1) fsIndex += "a";
-      if (id == 2) fsIndex += "b";
+      TString fsIndex("");
+      if (gNumericIndices && (id > 0)){
+        fsIndex += (++decayIndex);
+      }
+      else{
+        fsIndex += (im+1);
+        if (id == 1) fsIndex += "a";
+        if (id == 2) fsIndex += "b";
+      }
       cout << fsIndex << ". ";
       cout << name << " ";
       gMapGlueXNameToFSIndex[name] = fsIndex;


### PR DESCRIPTION
## Summary

Adds `-numericIndices [0 or 1]` to [`FlattenForFSRoot/flatten.cc`](https://github.com/JeffersonLab/hd_utilities/blob/flatten_numeric_decay_indices/FlattenForFSRoot/flatten.cc). Default `0` = current behaviour.

Decay products are currently named `P(n)a`/`P(n)b` after their mother's index, which puts them outside the integer index space. Code that reads an FSRoot tree by looping over an index range rather than by name therefore cannot reach them at all — the concrete case being [`FSRootDataReader`](https://github.com/JeffersonLab/halld_sim/blob/master/src/libraries/AMPTOOLS_DATAIO/FSRootDataReader.cc) and [`FSRootDataReaderBootstrap`](https://github.com/JeffersonLab/halld_sim/blob/master/src/libraries/AMPTOOLS_DATAIO/FSRootDataReaderBootstrap.cc) in `halld_sim`, which build branch names as `EnP1`…`EnP(N)` and cannot express an `a`/`b` postfix.

With `-numericIndices 1`, decay products are numbered consecutively **after all primaries**, so primaries keep exactly the indices they have today and only decay products are renamed. Asking a reader for the first `N` particles then gives the primaries first, decay products after, in order.

For $\Lambda\,p\,K^+\pi^+\pi^-\pi^0$ with $\Lambda\to p\pi^-$, $\pi^0\to\gamma\gamma$:

```
default:  1(Lambda)  1a(p)  1b(pi-)  2(p) 3(K+) 4(pi+) 5(pi-)  6(pi0)  6a(g)  6b(g)
numeric:  1(Lambda)   7(p)   8(pi-)  2(p) 3(K+) 4(pi+) 5(pi-)  6(pi0)   9(g)  10(g)
```

Documented in [`Documentation/GlueXFSRootFormat.tex`](https://github.com/JeffersonLab/hd_utilities/blob/flatten_numeric_decay_indices/FlattenForFSRoot/Documentation/GlueXFSRootFormat.tex), new subsection "Numeric indices for decay products".

## Compatibility

- Default unchanged, so existing trees and macros are unaffected.
- The mode-level tooling in the [FSRoot package](https://github.com/remitche66/FSRoot) (`EnP[pi+]`-style expansions, built from the mode code) only ever refers to primaries. Since primary indices don't move, those expansions are identical under either convention.
- The two conventions cannot be mixed within one tree.

## Verification

Tested on a $\Lambda\,p\,K^+\pi^+\pi^-\pi^0$ sample — picked because it has **two** decaying particles, exercising both the first and a later decay group, with charged and neutral daughters.

**1. Branch correspondence** (291 branches each way): 102 ↔ 102 renamed, 189 primary branches untouched, zero `P[0-9]+[ab]` left. Consistent across every prefix family — `En/Px/Py/Pz`, `R*` (measured), `MC*` (truth), `V*` (vertex), `Tk*` (track/PID), `ShQuality`. `VeeLP1`/`VeeLSigmaP1` correctly keep index 1, since vee variables key on the mother.

**2. Value round trip** (47 events → 132 combo entries), every legacy branch vs. its numeric counterpart, entry by entry via `TLeaf::GetValue`:

```
checked=216  (of which renamed=74)  mismatched=0  missing=0
PASS: numeric scheme is a pure renaming
```

**3. Default output unchanged** — pre-change `flatten` vs. new, same input, no flags:

```
entries=132 both   nbranches=216 both   branch name sets IDENTICAL
checked=216  mismatched=0
PASS: default output is bit-for-bit unchanged
```

Leaf type names compared as well as values. The flag turns on only for the exact string `1` (`0`, `2`, `yes`, empty all leave it false). The sole no-flag difference is stdout: five lines in the usage banner plus `numeric decay indices? 0` in the echoed parameters.

## Notes for the reviewer

- [`Documentation/GlueXFSRootFormat.pdf`](https://github.com/JeffersonLab/hd_utilities/blob/flatten_numeric_decay_indices/FlattenForFSRoot/Documentation/GlueXFSRootFormat.pdf) has **not** been regenerated — no `pdflatex` on the machine used. Only the `.tex` is updated; the PDF should be rebuilt before or at merge.
- The `id == 2` path (a third daughter, `P(n)b`) is preserved but untested — no current FS type produces a three-body decay group.
